### PR TITLE
Remove manual icon values to favor automatic icon extraction

### DIFF
--- a/Anthropic/Claude.fleet.recipe.yaml
+++ b/Anthropic/Claude.fleet.recipe.yaml
@@ -11,7 +11,7 @@ Input:
   - Developer tools
   
   # Optional: Icon file (leave empty for automatic extraction)
-  ICON: Claude.png
+  ICON: ""
 
   # Optional: Custom scripts and queries (leave empty if not needed)
   INSTALL_SCRIPT: ""

--- a/Caffeine/Caffeine.fleet.recipe.yaml
+++ b/Caffeine/Caffeine.fleet.recipe.yaml
@@ -11,7 +11,7 @@ Input:
   - Productivity
   
   # Optional: Icon file (leave empty for automatic extraction)
-  ICON: Caffeine.png
+  ICON: ""
 
   # Optional: Custom scripts and queries (leave empty if not needed)
   INSTALL_SCRIPT: ""

--- a/GPGSuite/GPGSuite.fleet.recipe.yaml
+++ b/GPGSuite/GPGSuite.fleet.recipe.yaml
@@ -12,7 +12,7 @@ Input:
   - Productivity
   
   # Optional: Icon file (leave empty for automatic extraction)
-  ICON: GPGSuite.png
+  ICON: ""
 
   # Optional: Custom scripts and queries (leave empty if not needed)
   INSTALL_SCRIPT: ""

--- a/GitHub/GithubDesktop.fleet.recipe.yaml
+++ b/GitHub/GithubDesktop.fleet.recipe.yaml
@@ -11,7 +11,7 @@ Input:
   - Developer tools
   
   # Optional: Icon file (leave empty for automatic extraction)
-  ICON: GithubDesktop.png
+  ICON: ""
 
   # Optional: Custom scripts and queries (leave empty if not needed)
   INSTALL_SCRIPT: ""

--- a/RaycastTechnologies/Raycast.fleet.recipe.yaml
+++ b/RaycastTechnologies/Raycast.fleet.recipe.yaml
@@ -11,7 +11,7 @@ Input:
   - Productivity
   
   # Optional: Icon file (leave empty for automatic extraction)
-  ICON: Raycast.png
+  ICON: ""
 
   # Optional: Custom scripts and queries (leave empty if not needed)
   INSTALL_SCRIPT: ""

--- a/Signal/Signal.fleet.recipe.yaml
+++ b/Signal/Signal.fleet.recipe.yaml
@@ -11,7 +11,7 @@ Input:
   - Communication
   
   # Optional: Icon file (leave empty for automatic extraction)
-  ICON: Signal.png
+  ICON: ""
 
   # Optional: Custom scripts and queries (leave empty if not needed)
   INSTALL_SCRIPT: ""


### PR DESCRIPTION
Changed ICON values from specific filenames to empty strings for:
- Anthropic/Claude.fleet.recipe.yaml
- Caffeine/Caffeine.fleet.recipe.yaml
- GitHub/GithubDesktop.fleet.recipe.yaml
- GPGSuite/GPGSuite.fleet.recipe.yaml
- RaycastTechnologies/Raycast.fleet.recipe.yaml
- Signal/Signal.fleet.recipe.yaml

This allows FleetImporter to automatically extract icons from package files.