### PR TITLE
Fix icon extraction for packages with Payload archives and asset catalogs

### DIFF
--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -887,7 +887,9 @@ class FleetImporter(Processor):
                         self.output(
                             "No .icns file found. Attempting to extract icon using macOS icon services..."
                         )
-                        temp_png = Path(tempfile.gettempdir()) / f"{app_bundle.stem}_icon.png"
+                        temp_png = (
+                            Path(tempfile.gettempdir()) / f"{app_bundle.stem}_icon.png"
+                        )
                         try:
                             # Use Python with Cocoa (PyObjC) to get the app's icon
                             # This is available in macOS's system Python
@@ -899,11 +901,15 @@ class FleetImporter(Processor):
                             if app_icon:
                                 # Get the largest representation (usually 512x512 or 1024x1024)
                                 tiff_data = app_icon.TIFFRepresentation()
-                                bitmap_rep = Cocoa.NSBitmapImageRep.imageRepWithData_(tiff_data)
+                                bitmap_rep = Cocoa.NSBitmapImageRep.imageRepWithData_(
+                                    tiff_data
+                                )
 
                                 # Convert to PNG
-                                png_data = bitmap_rep.representationUsingType_properties_(
-                                    Cocoa.NSBitmapImageFileTypePNG, None
+                                png_data = (
+                                    bitmap_rep.representationUsingType_properties_(
+                                        Cocoa.NSBitmapImageFileTypePNG, None
+                                    )
                                 )
 
                                 # Write PNG file
@@ -917,7 +923,9 @@ class FleetImporter(Processor):
                                 else:
                                     self.output("Warning: Icon file created but empty")
                             else:
-                                self.output("Warning: Could not get app icon from macOS")
+                                self.output(
+                                    "Warning: Could not get app icon from macOS"
+                                )
 
                         except ImportError:
                             self.output(


### PR DESCRIPTION
## Summary

This PR fixes icon extraction for modern macOS applications that use asset catalogs instead of traditional .icns files, and for packages where the .app bundle is nested inside Payload archives.

## Changes

### 1. Fixed Error 17: File exists
- Removed pkg_expand_dir.mkdir() call that caused the error
- pkgutil --expand creates the directory itself and fails if it already exists

### 2. Added Payload archive support
- Detects and extracts Payload archives within expanded packages
- Tries multiple tar extraction methods: gzip, bzip2, and uncompressed
- Searches extracted Payload for .app bundles
- Handles packages like UTM where .app is inside compressed Payload

### 3. Enhanced asset catalog icon extraction
- First try: CFBundleIconFile (legacy .icns path) - existing behavior
- Second try: CFBundleIconName with .icns file search in Resources
- Third try: PyObjC/Cocoa NSWorkspace API to extract icons from Assets.car

## Testing

Tested successfully with UTM 4.7.4:
- Expands package successfully
- Finds Payload archive and extracts it
- Detects CFBundleIconName: AppIcon
- Extracts 1.7MB icon using PyObjC/Cocoa
- Compresses to 50.8KB (256x256px) to meet Fleet 100KB limit
- Uploads icon successfully to Fleet