### PR TITLE
Add 14 Fleet recipes from autopkg/recipes

### DIFF
--- a/Barebones/BBEdit.fleet.recipe.yaml
+++ b/Barebones/BBEdit.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds BBEdit.pkg and uploads to Fleet"
+Identifier: com.github.fleet.BBEdit
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.BBEdit
+
+Input:
+  NAME: BBEdit
+  self_service: true
+  automatic_install: false
+  categories:
+  - Developer tools
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/Cyberduck/Cyberduck.fleet.recipe.yaml
+++ b/Cyberduck/Cyberduck.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds Cyberduck.pkg and uploads to Fleet"
+Identifier: com.github.fleet.Cyberduck
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.Cyberduck
+
+Input:
+  NAME: Cyberduck
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/Dropbox/Dropbox.fleet.recipe.yaml
+++ b/Dropbox/Dropbox.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds Dropbox.pkg and uploads to Fleet"
+Identifier: com.github.fleet.Dropbox
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.dropbox
+
+Input:
+  NAME: Dropbox
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/Evernote/Evernote.fleet.recipe.yaml
+++ b/Evernote/Evernote.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds Evernote.pkg and uploads to Fleet"
+Identifier: com.github.fleet.Evernote
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.Evernote
+
+Input:
+  NAME: Evernote
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/Handbrake/Handbrake.fleet.recipe.yaml
+++ b/Handbrake/Handbrake.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds Handbrake.pkg and uploads to Fleet"
+Identifier: com.github.fleet.Handbrake
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.Handbrake
+
+Input:
+  NAME: Handbrake
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/MacPaw/TheUnarchiver.fleet.recipe.yaml
+++ b/MacPaw/TheUnarchiver.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds TheUnarchiver.pkg and uploads to Fleet"
+Identifier: com.github.fleet.TheUnarchiver
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.TheUnarchiver
+
+Input:
+  NAME: The Unarchiver
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/Mozilla/Thunderbird.fleet.recipe.yaml
+++ b/Mozilla/Thunderbird.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds Thunderbird.pkg and uploads to Fleet"
+Identifier: com.github.fleet.Thunderbird
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.Thunderbird
+
+Input:
+  NAME: Thunderbird
+  self_service: true
+  automatic_install: false
+  categories:
+  - Communication
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/OmniGroup/OmniDiskSweeper.fleet.recipe.yaml
+++ b/OmniGroup/OmniDiskSweeper.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds OmniDiskSweeper.pkg and uploads to Fleet"
+Identifier: com.github.fleet.OmniDiskSweeper
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.OmniDiskSweeper
+
+Input:
+  NAME: OmniDiskSweeper
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/OmniGroup/OmniFocus.fleet.recipe.yaml
+++ b/OmniGroup/OmniFocus.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds OmniFocus.pkg and uploads to Fleet"
+Identifier: com.github.fleet.OmniFocus
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.omnifocus
+
+Input:
+  NAME: OmniFocus
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/OmniGroup/OmniGraffle.fleet.recipe.yaml
+++ b/OmniGroup/OmniGraffle.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds OmniGraffle.pkg and uploads to Fleet"
+Identifier: com.github.fleet.OmniGraffle
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.omnigraffle
+
+Input:
+  NAME: OmniGraffle
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/OmniGroup/OmniOutliner.fleet.recipe.yaml
+++ b/OmniGroup/OmniOutliner.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds OmniOutliner.pkg and uploads to Fleet"
+Identifier: com.github.fleet.OmniOutliner
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.omnioutliner
+
+Input:
+  NAME: OmniOutliner
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/OmniGroup/OmniPlan.fleet.recipe.yaml
+++ b/OmniGroup/OmniPlan.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds OmniPlan.pkg and uploads to Fleet"
+Identifier: com.github.fleet.OmniPlan
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.omniplan
+
+Input:
+  NAME: OmniPlan
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/Panic/Transmit.fleet.recipe.yaml
+++ b/Panic/Transmit.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds Transmit.pkg and uploads to Fleet"
+Identifier: com.github.fleet.Transmit
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.transmit
+
+Input:
+  NAME: Transmit
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter

--- a/VLC/VLC.fleet.recipe.yaml
+++ b/VLC/VLC.fleet.recipe.yaml
@@ -1,0 +1,49 @@
+Description: "Builds VLC.pkg and uploads to Fleet"
+Identifier: com.github.fleet.VLC
+MinimumVersion: "2.3"
+ParentRecipe: com.github.autopkg.pkg.VLC
+
+Input:
+  NAME: VLC
+  self_service: true
+  automatic_install: false
+  categories:
+  - Productivity
+  
+  ICON: ""
+  INSTALL_SCRIPT: ""
+  UNINSTALL_SCRIPT: ""
+  PRE_INSTALL_QUERY: ""
+  POST_INSTALL_SCRIPT: ""
+  
+  labels_include_any: []
+  labels_exclude_any: []
+  
+  gitops_mode: false
+  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
+  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  s3_retention_versions: 0
+
+Process:
+- Arguments:
+    pkg_path: "%pkg_path%"
+    software_title: "%NAME%"
+    version: "%version%"
+    icon: "%ICON%"
+    install_script: "%INSTALL_SCRIPT%"
+    uninstall_script: "%UNINSTALL_SCRIPT%"
+    pre_install_query: "%PRE_INSTALL_QUERY%"
+    post_install_script: "%POST_INSTALL_SCRIPT%"
+    gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
+    fleet_api_base: "%FLEET_API_BASE%"
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    team_id: "%FLEET_TEAM_ID%"
+    aws_s3_bucket: "%AWS_S3_BUCKET%"
+    aws_cloudfront_domain: "%AWS_CLOUDFRONT_DOMAIN%"
+    aws_access_key_id: "%AWS_ACCESS_KEY_ID%"
+    aws_secret_access_key: "%AWS_SECRET_ACCESS_KEY%"
+    aws_default_region: "%AWS_DEFAULT_REGION%"
+    gitops_repo_url: "%FLEET_GITOPS_REPO_URL%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+  Processor: com.github.fleet.FleetImporter/FleetImporter


### PR DESCRIPTION
This PR adds 14 new Fleet recipes for popular macOS software packages, sourced from the [autopkg/recipes](https://github.com/autopkg/recipes) repository.

## Changes

### New Fleet Recipes Added

**Developer Tools:**
- **BBEdit** - Professional text and code editor by Bare Bones Software

**Productivity Tools:**
- **VLC** - Popular open-source media player
- **Dropbox** - Cloud storage and file synchronization
- **Handbrake** - Video transcoding application
- **Evernote** - Note-taking and organization software
- **Cyberduck** - FTP/SFTP client
- **The Unarchiver** - Archive extraction utility (MacPaw)
- **Transmit** - File transfer client (Panic)
- **OmniFocus** - Task management application
- **OmniGraffle** - Diagramming and digital illustration
- **OmniOutliner** - Outlining and note organization
- **OmniPlan** - Project management software
- **OmniDiskSweeper** - Disk space management utility

**Communication:**
- **Thunderbird** - Mozilla's email client
