### PR TITLE
Fix IconGrabber recipe path and add testing script

### DIFF
--- a/Kitzy/IconGrabber.fleet.recipe.yaml
+++ b/Kitzy/IconGrabber.fleet.recipe.yaml
@@ -37,7 +37,7 @@ Input:
 Process:
 - Arguments:
     # Core package info
-    pkg_path: "%pkg_path%"
+    pkg_path: "%pathname%"
     software_title: "%NAME%"
     version: "%version%"
     display_name: "%NAME%"

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Change to the repository root (parent of tests directory)
+cd "$(dirname "$0")/.." || exit 1
+
+# Run all Fleet recipes in subdirectories, excluding _templates
+for recipe in */*.fleet.recipe.yaml; do
+    # Skip anything in _templates directory
+    if [[ "$recipe" == _templates/* ]]; then
+        continue
+    fi
+    
+    echo "Running $recipe..."
+    # Use ./ prefix to ensure we run the local recipe, not one from AutoPkg's repo cache
+    autopkg run -v "./$recipe"
+done


### PR DESCRIPTION
Correct the path variable in the IconGrabber recipe and introduce a script to run all recipes for testing purposes.