### PR TITLE
docs: link Fleet's AutoPkg guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A community-maintained repo of AutoPkg recipes for uploading macOS installer pac
 
 Run `autopkg repo-add fleet-recipes` to add this repo.
 
+> **New to AutoPkg with Fleet?** See Fleet's official guide [Using AutoPkg with Fleet](https://fleetdm.com/guides/autopkg-with-fleet) for an end-to-end walkthrough of the workflow these recipes are built around.
+
 ### Recipe Dependencies
 
 Fleet recipes depend on parent recipes from other AutoPkg repositories. See [PARENT_RECIPE_DEPENDENCIES.md](PARENT_RECIPE_DEPENDENCIES.md) for the complete list of required repositories and setup instructions.


### PR DESCRIPTION
## Summary
- Adds a callout in the README Getting started section linking to Fleet's official guide [Using AutoPkg with Fleet](https://fleetdm.com/guides/autopkg-with-fleet), so newcomers landing on this repo have an end-to-end primer on the workflow these recipes plug into.

## Test plan
- [x] Verify the link renders on GitHub and points to the correct Fleet guide.
- [x] Confirm placement reads naturally between the `repo-add` instruction and the Recipe Dependencies subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)