### PR TITLE
FleetImporter: cache the boto3 S3 client across calls

### DIFF
--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -1787,7 +1787,7 @@ class FleetImporter(Processor):
         return access_key, secret_key, region
 
     def _get_s3_client(self):
-        """Get configured boto3 S3 client.
+        """Get configured boto3 S3 client, cached per processor instance.
 
         Returns:
             boto3 S3 client
@@ -1803,6 +1803,12 @@ class FleetImporter(Processor):
 
         access_key, secret_key, region = self._get_aws_credentials()
 
+        cached = getattr(self, "_cached_s3_client", None)
+        cached_key = getattr(self, "_cached_s3_client_key", None)
+        client_key = (access_key, region)
+        if cached is not None and cached_key == client_key:
+            return cached
+
         try:
             s3_client = boto3.client(
                 "s3",
@@ -1810,6 +1816,8 @@ class FleetImporter(Processor):
                 aws_secret_access_key=secret_key,
                 region_name=region,
             )
+            self._cached_s3_client = s3_client
+            self._cached_s3_client_key = client_key
             return s3_client
         except Exception as e:
             raise ProcessorError(f"Failed to create S3 client: {e}")


### PR DESCRIPTION
## Summary

Reuses a single boto3 S3 client (and its connection pool) across `_upload_to_s3`, `_cleanup_old_s3_versions`, and `_calculate_s3_file_sha256` within a single processor run. Previously each call rebuilt the client from scratch, paying TCP+TLS setup three times per recipe.

The cache is stored as `_cached_s3_client` on the processor instance and keyed on `(access_key, region)` so credential changes mid-run still rebuild the client.

Split out from #56 — addresses one of the five issues bundled there.

Closes #28.

## Test plan

- [x] \`pre-commit run --files FleetImporter/FleetImporter.py\` (black, isort, flake8) clean
- [x] \`python -m unittest tests.test_auto_update\` — 33 tests pass
- [ ] Smoke-test a GitOps-mode recipe run end-to-end and verify only one client is created (the upload, cleanup, and hash paths share it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)