### PR TITLE
FleetImporter: validate aws_cloudfront_domain before constructing URLs

### DIFF
--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -1896,9 +1896,44 @@ class FleetImporter(Processor):
 
         Returns:
             Full CloudFront HTTPS URL
+
+        Raises:
+            ProcessorError: If the domain is empty, contains an http:// scheme,
+                            or includes path/query components.
         """
-        # Remove any leading/trailing slashes from domain
-        domain = cloudfront_domain.strip("/")
+        if not cloudfront_domain or not cloudfront_domain.strip():
+            raise ProcessorError(
+                "aws_cloudfront_domain is empty. A CloudFront distribution "
+                "domain (e.g., d1234abcd.cloudfront.net or cdn.example.com) "
+                "is required for GitOps mode."
+            )
+
+        domain = cloudfront_domain.strip().strip("/")
+
+        # Reject explicit http:// — Fleet downloads must be HTTPS to avoid
+        # serving packages over an unauthenticated channel.
+        lower = domain.lower()
+        if lower.startswith("http://"):
+            raise ProcessorError(
+                f"aws_cloudfront_domain must be served over HTTPS, got: "
+                f"{cloudfront_domain!r}. Provide the domain only "
+                "(e.g., d1234abcd.cloudfront.net), not an http:// URL."
+            )
+        if lower.startswith("https://"):
+            domain = domain[8:]
+
+        # A bare domain has no path/query/fragment.
+        if any(ch in domain for ch in ("/", "?", "#")):
+            raise ProcessorError(
+                f"aws_cloudfront_domain must be a bare hostname (no path or "
+                f"query), got: {cloudfront_domain!r}."
+            )
+        if " " in domain or not domain:
+            raise ProcessorError(
+                f"aws_cloudfront_domain is not a valid hostname: "
+                f"{cloudfront_domain!r}."
+            )
+
         # Ensure s3_key doesn't start with /
         key = s3_key.lstrip("/")
         return f"https://{domain}/{key}"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ FleetImporter recipes support the following variables. Configuration can be set 
 | `FLEET_TEAM_ID` | Required | Not used | - | Fleet team ID for software assignment |
 | **AWS S3 (GitOps Mode)** | | | | |
 | `AWS_S3_BUCKET` | Not used | Required | - | S3 bucket name for package storage |
-| `AWS_CLOUDFRONT_DOMAIN` | Not used | Required | - | CloudFront domain for package URLs |
+| `AWS_CLOUDFRONT_DOMAIN` | Not used | Required | - | CloudFront domain for package URLs. Must be a bare HTTPS hostname with no scheme, path, or query (e.g., `d1234abcd.cloudfront.net` or `cdn.example.com`) |
 | `AWS_ACCESS_KEY_ID` | Not used | Optional | - | AWS access key (can use `~/.aws/credentials` instead) |
 | `AWS_SECRET_ACCESS_KEY` | Not used | Optional | - | AWS secret key (can use `~/.aws/credentials` instead) |
 | `AWS_DEFAULT_REGION` | Not used | Required | `us-east-1` | AWS region for S3 operations |


### PR DESCRIPTION
## Summary

Validates \`aws_cloudfront_domain\` in \`_construct_cloudfront_url\` before stitching it into the package URL. Reject empty values, \`http://\` schemes, and any path/query/fragment so a misconfigured input fails fast with a clear error instead of silently emitting a malformed or insecure URL into the GitOps YAML. \`https://\` prefixes are accepted and stripped.

Split out from #56 — addresses one of the five issues bundled there.

Closes #21.

## Test plan

- [x] \`pre-commit run --files FleetImporter/FleetImporter.py\` (black, isort, flake8) clean
- [x] \`python -m unittest tests.test_auto_update\` — 33 tests pass
- [ ] Smoke-test: pass an empty domain, an \`http://\` URL, a domain with a path, and a normal domain through a recipe run; confirm the first three error out and the last works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)