### PR TITLE
Coerce numeric env vars to strings before AutoPkg substitution

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -376,11 +376,30 @@ jobs:
       run: |
         python tests/test_style_guide_compliance.py
 
+  validate-unit-tests:
+    name: Processor Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Run unittest suite
+      run: |
+        python -m unittest -v \
+          tests.test_auto_update \
+          tests.test_inject_coercion
+
   validate-final:
     name: Final Validation Summary
     runs-on: ubuntu-latest
-    needs: [validate-python, validate-environment-variables, validate-recipe-structure, security-check, integration-test, validate-style-guide]
-    
+    needs: [validate-python, validate-environment-variables, validate-recipe-structure, security-check, integration-test, validate-style-guide, validate-unit-tests]
+
     steps:
     - name: Summary
       run: |
@@ -392,5 +411,6 @@ jobs:
         echo "✅ Security and best practices check"
         echo "✅ Integration test"
         echo "✅ Style guide compliance (includes YAML validation)"
+        echo "✅ Processor unit tests"
         echo ""
         echo "Ready for merge! 🚀"

--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -235,6 +235,37 @@ class FleetImporter(Processor):
         },
     }
 
+    # Matches AutoPkg's %KEY% substitution pattern.
+    _ENV_REF_RE = re.compile(r"%([^%]+)%")
+
+    def inject(self, arguments) -> None:
+        # AutoPkg's do_variable_substitution uses re.sub, which raises
+        # "TypeError: sequence item 0: expected str instance, int found" when a
+        # referenced env value is numeric. Defaults written as `-int` (e.g.
+        # FLEET_TEAM_ID) trip this. Coerce referenced numeric env entries to
+        # strings so substitution works regardless of how the user stored them.
+        for key in self._collect_referenced_keys(arguments):
+            value = self.env.get(key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, (int, float)):
+                self.env[key] = str(value)
+        super().inject(arguments)
+
+    @classmethod
+    def _collect_referenced_keys(cls, value) -> set[str]:
+        """Return the set of %KEY% names referenced anywhere in value."""
+        keys: set[str] = set()
+        if isinstance(value, str):
+            keys.update(cls._ENV_REF_RE.findall(value))
+        elif isinstance(value, dict):
+            for v in value.values():
+                keys.update(cls._collect_referenced_keys(v))
+        elif isinstance(value, (list, tuple)):
+            for v in value:
+                keys.update(cls._collect_referenced_keys(v))
+        return keys
+
     def _get_ssl_context(self):
         """Create an SSL context using certifi's CA bundle."""
         return ssl.create_default_context(cafile=certifi.where())

--- a/tests/test_inject_coercion.py
+++ b/tests/test_inject_coercion.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Unit tests for FleetImporter.inject() numeric coercion.
+
+Background:
+    AutoPkg's do_variable_substitution uses re.sub against env values. If a
+    referenced %KEY% resolves to an int (e.g. FLEET_TEAM_ID stored via
+    `defaults write … -int 1`), substitution fails with
+    "TypeError: sequence item 0: expected str instance, int found" before the
+    processor's main() runs.
+
+    FleetImporter.inject() works around this by coercing numeric env entries
+    that are referenced via %KEY% in the step's Arguments. Booleans are left
+    alone (bool is an int subclass in Python and stringifying it would change
+    semantics for keys like gitops_mode).
+
+These tests replicate the coercion logic from FleetImporter without importing
+AutoPkg, matching the pattern used in test_auto_update.py.
+"""
+
+import re
+import unittest
+
+ENV_REF_RE = re.compile(r"%([^%]+)%")
+
+
+def collect_referenced_keys(value):
+    keys = set()
+    if isinstance(value, str):
+        keys.update(ENV_REF_RE.findall(value))
+    elif isinstance(value, dict):
+        for v in value.values():
+            keys.update(collect_referenced_keys(v))
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            keys.update(collect_referenced_keys(v))
+    return keys
+
+
+def coerce_referenced_numerics(env, arguments):
+    for key in collect_referenced_keys(arguments):
+        value = env.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            env[key] = str(value)
+    return env
+
+
+class TestCollectReferencedKeys(unittest.TestCase):
+    def test_extracts_keys_from_string(self):
+        self.assertEqual(collect_referenced_keys("%FOO%/%BAR%"), {"FOO", "BAR"})
+
+    def test_walks_into_dicts_and_lists(self):
+        args = {
+            "a": "%ONE%",
+            "b": ["%TWO%", {"c": "%THREE%"}],
+            "d": "literal",
+        }
+        self.assertEqual(collect_referenced_keys(args), {"ONE", "TWO", "THREE"})
+
+    def test_no_keys_returns_empty(self):
+        self.assertEqual(collect_referenced_keys("no refs here"), set())
+
+
+class TestCoerceReferencedNumerics(unittest.TestCase):
+    def test_coerces_int_team_id(self):
+        env = {"FLEET_TEAM_ID": 1}
+        coerce_referenced_numerics(env, {"team_id": "%FLEET_TEAM_ID%"})
+        self.assertEqual(env["FLEET_TEAM_ID"], "1")
+
+    def test_coerces_float(self):
+        env = {"PORT": 8080.0}
+        coerce_referenced_numerics(env, {"port": "%PORT%"})
+        self.assertEqual(env["PORT"], "8080.0")
+
+    def test_leaves_strings_alone(self):
+        env = {"FLEET_TEAM_ID": "1"}
+        coerce_referenced_numerics(env, {"team_id": "%FLEET_TEAM_ID%"})
+        self.assertEqual(env["FLEET_TEAM_ID"], "1")
+
+    def test_does_not_coerce_booleans(self):
+        # bool is a subclass of int; coercing would change semantics for
+        # keys like gitops_mode where downstream code does `if env[key]`.
+        env = {"gitops_mode": False}
+        coerce_referenced_numerics(env, {"flag": "%gitops_mode%"})
+        self.assertIs(env["gitops_mode"], False)
+
+    def test_skips_unreferenced_keys(self):
+        env = {"FLEET_TEAM_ID": 1, "OTHER_INT": 99}
+        coerce_referenced_numerics(env, {"team_id": "%FLEET_TEAM_ID%"})
+        self.assertEqual(env["FLEET_TEAM_ID"], "1")
+        self.assertEqual(env["OTHER_INT"], 99)
+
+    def test_handles_nested_arguments(self):
+        env = {"A": 1, "B": 2}
+        args = {"x": ["%A%"], "y": {"z": "%B%"}}
+        coerce_referenced_numerics(env, args)
+        self.assertEqual(env["A"], "1")
+        self.assertEqual(env["B"], "2")
+
+    def test_missing_env_key_is_ignored(self):
+        env = {}
+        # Should not raise — substitution will fail later with a clearer error.
+        coerce_referenced_numerics(env, {"team_id": "%FLEET_TEAM_ID%"})
+        self.assertEqual(env, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Override `Processor.inject()` in FleetImporter to coerce referenced `int`/`float` env values to strings before AutoPkg's `do_variable_substitution` runs. Booleans are explicitly skipped so flags like `gitops_mode` keep their semantics.
- Add `tests/test_inject_coercion.py` with 10 unit tests covering the coercion logic, the bool exclusion, nested arguments, and missing-key safety. Mirrors the autopkglib-free pattern used by `test_auto_update.py`.
- Add a `validate-unit-tests` CI job that runs both unittest modules explicitly (skipping `test_style_guide_compliance.py`, which already has its own job).

## Why

When a user runs `defaults write com.github.autopkg FLEET_TEAM_ID -int 1` instead of writing the value as a string, every Fleet recipe in this repo fails before `FleetImporter.main()` is reached:

```
File "/Library/AutoPkg/autopkglib/__init__.py", line 436, in do_variable_substitution
    item = RE_KEYREF.sub(getdata, item)
TypeError: sequence item 0: expected str instance, int found
```

`re.sub`'s replacement function must return a string; an int trips the error during result concatenation. The recipe template at `_templates/Template.fleet.recipe.yaml` references `team_id: "%FLEET_TEAM_ID%"`, which is the most common trigger — but the same bug applies to any numeric env value referenced via `%KEY%`.

The override targets only the keys actually referenced in the current step's Arguments, so a downstream consumer that pulls a non-string scalar straight from `self.env` is unaffected.

## Test plan

- [x] `python3.13 -m unittest -v tests.test_auto_update tests.test_inject_coercion` — 43 tests pass locally
- [x] Pre-commit hooks (black, isort, flake8) pass on the new code
- [ ] CI green on this PR (validate-unit-tests job runs the new suite)
- [ ] Manual verification on a host where `defaults write … FLEET_TEAM_ID -int 1` previously crashed: confirm a `.fleet.recipe.yaml` now reaches FleetImporter and uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)