### PR TITLE
Add support for GitHub App auth

### DIFF
--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -138,6 +138,14 @@ class FleetImporter(Processor):
             "required": False,
             "description": "Filesystem path to the GitHub App's private key in PEM format (chmod 600). The key is never logged and is passed to openssl via -sign. Use FLEET_GITOPS_GITHUB_APP_PRIVATE_KEY_PATH environment variable.",
         },
+        "github_app_bot_slug": {
+            "required": False,
+            "description": "The GitHub App's slug (the bot account login is '<slug>[bot]', e.g. 'autopkg' for 'autopkg[bot]'). Required when using GitHub App auth so the commit author label uses the correct bot name. Use FLEET_GITOPS_GITHUB_APP_BOT_SLUG environment variable.",
+        },
+        "github_app_bot_user_id": {
+            "required": False,
+            "description": "Numeric user ID of the App's bot account ('<slug>[bot]'). This is a DIFFERENT integer from the App ID — find it via https://api.github.com/users/<slug>%5Bbot%5D (response 'id' field) or the equivalent on your GitHub Enterprise host. Required when using GitHub App auth so commits link to the bot's GitHub profile via the noreply email format. Use FLEET_GITOPS_GITHUB_APP_BOT_USER_ID environment variable.",
+        },
         "s3_retention_versions": {
             "required": False,
             "default": 0,
@@ -989,6 +997,8 @@ class FleetImporter(Processor):
         # token is itself a Bearer credential the rest of the workflow can use
         # interchangeably with a PAT for both git HTTPS and the REST API.
         using_github_app = False
+        bot_slug = None
+        bot_user_id = None
         if have_app_creds:
             _, _, _, api_base = self._parse_github_repo_url(gitops_repo_url)
             self.output("Minting GitHub App installation token...")
@@ -999,10 +1009,30 @@ class FleetImporter(Processor):
                 github_app_private_key_path,
             )
             using_github_app = True
+
+            bot_slug = self.env.get("github_app_bot_slug")
+            bot_user_id_env = self.env.get("github_app_bot_user_id")
+            if not bot_slug or not bot_user_id_env:
+                raise ProcessorError(
+                    "GitHub App authentication requires github_app_bot_slug "
+                    "and github_app_bot_user_id. The bot login is "
+                    "'<slug>[bot]'; the user ID is a SEPARATE integer from "
+                    "the App ID. Both are required so commits link to the "
+                    "bot's GitHub profile via the noreply email format."
+                )
+            try:
+                bot_user_id = int(str(bot_user_id_env).strip())
+            except ValueError:
+                raise ProcessorError(
+                    "github_app_bot_user_id must be numeric, got: "
+                    f"{bot_user_id_env!r}"
+                )
+
             self.output(
                 f"Using GitHub App authentication (App ID {github_app_id}, "
-                f"installation {github_app_installation_id}) — PRs and commits "
-                "will be authored by the App's bot identity."
+                f"installation {github_app_installation_id}, bot "
+                f"{bot_slug}[bot] id={bot_user_id}) — PRs and commits will "
+                f"be authored by {bot_slug}[bot]."
             )
         else:
             self.output(
@@ -1093,7 +1123,7 @@ class FleetImporter(Processor):
             # push (which would fail with a non-fast-forward error against the
             # orphan branch). Mirror the "already exists in Fleet/S3" pattern.
             branch_name = f"autopkg/{self._slugify(software_title)}-{version}"
-            if self._remote_branch_exists(temp_dir, branch_name):
+            if self._remote_branch_exists(temp_dir, branch_name, github_token):
                 self.output(
                     f"Remote branch '{branch_name}' already exists — "
                     f"{software_title} {version} was previously imported."
@@ -1253,7 +1283,8 @@ class FleetImporter(Processor):
                 policy_yaml_path,
                 github_token=github_token,
                 using_github_app=using_github_app,
-                github_app_id=github_app_id,
+                bot_slug=bot_slug,
+                bot_user_id=bot_user_id,
             )
             self.env["git_branch"] = branch_name
 
@@ -2187,8 +2218,9 @@ class FleetImporter(Processor):
             ProcessorError: If clone fails
         """
         temp_dir = tempfile.mkdtemp(prefix="fleetimporter-gitops-")
-        askpass_script, git_env = self._make_git_auth_env(github_token)
+        askpass_script = None
         try:
+            askpass_script, git_env = self._make_git_auth_env(github_token)
             subprocess.run(
                 ["git", "clone", repo_url, temp_dir],
                 check=True,
@@ -2198,11 +2230,18 @@ class FleetImporter(Processor):
             )
             return temp_dir
         except subprocess.CalledProcessError as e:
-            if Path(temp_dir).exists():
-                shutil.rmtree(temp_dir, ignore_errors=True)
+            shutil.rmtree(temp_dir, ignore_errors=True)
             raise ProcessorError(
                 f"Failed to clone GitOps repository: {e.stderr or e.stdout}"
             )
+        except BaseException:
+            # Any other failure between mkdtemp and the successful return —
+            # most plausibly mkstemp/os.write inside _make_git_auth_env —
+            # would otherwise orphan temp_dir, since the only narrow except
+            # above won't match. Clean up then re-raise so callers see the
+            # original exception unchanged.
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            raise
         finally:
             if askpass_script and os.path.exists(askpass_script):
                 try:
@@ -2408,7 +2447,8 @@ class FleetImporter(Processor):
         policy_yaml_path: str = None,
         github_token: str = None,
         using_github_app: bool = False,
-        github_app_id: str = None,
+        bot_slug: str = None,
+        bot_user_id: int = None,
     ):
         """Create Git branch, commit changes, and push to remote.
 
@@ -2422,10 +2462,15 @@ class FleetImporter(Processor):
             icon_path: Optional relative path to icon file (e.g., ../../icons/claude.png)
             policy_yaml_path: Optional relative path to policy YAML file (e.g., lib/policies/chrome.yml)
             github_token: PAT or App installation access token used for the push.
-            using_github_app: When True, set commit author to the App bot so commits
-                aren't attributed to the host user.
-            github_app_id: App ID, used to construct the bot's noreply email when
-                using_github_app is True.
+            using_github_app: When True, attribute commits to the App bot using
+                ``bot_slug`` and ``bot_user_id`` so the commit author label
+                links to the bot's GitHub profile.
+            bot_slug: App slug (the bot login is ``<bot_slug>[bot]``). Required
+                when ``using_github_app`` is True.
+            bot_user_id: Numeric user ID of the ``<bot_slug>[bot]`` account.
+                Different from the App ID. Required when ``using_github_app``
+                is True so the noreply email links commits to the bot's
+                profile.
 
         Raises:
             ProcessorError: If Git operations fail
@@ -2457,13 +2502,18 @@ class FleetImporter(Processor):
             # commit to the App's bot account so `git log` doesn't show the
             # host user. PR author is set independently by whoever calls the
             # create-PR API, but commit author is what most reviewers look at.
+            # The noreply format <user_id>+<login>@users.noreply.github.com is
+            # what makes the commit author label link back to the bot's
+            # profile in GitHub's UI; both parts are caller-supplied since the
+            # bot user ID is distinct from the App ID and the slug is whatever
+            # the App owner chose.
             if using_github_app:
-                bot_name = "autopkg[bot]"
-                bot_email = (
-                    f"{github_app_id}+autopkg[bot]@users.noreply.github.com"
-                    if github_app_id
-                    else "autopkg[bot]@users.noreply.github.com"
-                )
+                if not bot_slug or bot_user_id is None:
+                    raise ProcessorError(
+                        "using_github_app=True requires bot_slug and " "bot_user_id"
+                    )
+                bot_name = f"{bot_slug}[bot]"
+                bot_email = f"{bot_user_id}+{bot_slug}[bot]@users.noreply.github.com"
                 subprocess.run(
                     ["git", "config", "user.name", bot_name],
                     cwd=repo_dir,
@@ -2704,32 +2754,45 @@ class FleetImporter(Processor):
         }
         return askpass_path, git_env
 
-    def _remote_branch_exists(self, repo_dir: str, branch_name: str) -> bool:
+    def _remote_branch_exists(
+        self, repo_dir: str, branch_name: str, github_token: str
+    ) -> bool:
         """Return True if ``branch_name`` exists on the ``origin`` remote.
 
         Used to keep the GitOps workflow idempotent: re-running a recipe for
         a version whose branch was already pushed must not blow up with a
         non-fast-forward push (see #70).
+
+        ``github_token`` must be threaded through (rather than relying on the
+        macOS credential helper having cached creds during the preceding
+        clone) so this works under GitHub App auth, where each run uses a
+        short-lived installation token the keychain has never seen. The
+        previous implicit-cache path also risked silently falling back to
+        the host user's PAT, which would defeat the bot-identity isolation.
         """
-        git_env = {
-            "GIT_TERMINAL_PROMPT": "0",
-            "PATH": os.environ.get("PATH", ""),
-            "HOME": os.environ.get("HOME", ""),
-        }
-        # `--exit-code` returns 2 when no refs match, 0 on match.
-        result = subprocess.run(
-            [
-                "git",
-                "ls-remote",
-                "--exit-code",
-                "origin",
-                f"refs/heads/{branch_name}",
-            ],
-            cwd=repo_dir,
-            capture_output=True,
-            text=True,
-            env=git_env,
-        )
+        askpass_script = None
+        try:
+            askpass_script, git_env = self._make_git_auth_env(github_token)
+            # `--exit-code` returns 2 when no refs match, 0 on match.
+            result = subprocess.run(
+                [
+                    "git",
+                    "ls-remote",
+                    "--exit-code",
+                    "origin",
+                    f"refs/heads/{branch_name}",
+                ],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+                env=git_env,
+            )
+        finally:
+            if askpass_script and os.path.exists(askpass_script):
+                try:
+                    os.unlink(askpass_script)
+                except Exception:
+                    pass  # Best effort cleanup
         if result.returncode == 0:
             return True
         if result.returncode == 2:

--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import io
 import json
@@ -123,7 +124,19 @@ class FleetImporter(Processor):
         },
         "github_token": {
             "required": False,
-            "description": "GitHub personal access token for cloning and creating PRs (required for GitOps mode). Use FLEET_GITOPS_GITHUB_TOKEN environment variable.",
+            "description": "GitHub personal access token for cloning and creating PRs. Use FLEET_GITOPS_GITHUB_TOKEN environment variable. Either this OR the github_app_* inputs are required for GitOps mode; App credentials are preferred so PRs are authored by the App's bot identity rather than a human user.",
+        },
+        "github_app_id": {
+            "required": False,
+            "description": "GitHub App ID (numeric). When github_app_id, github_app_installation_id, and github_app_private_key_path are all set, a short-lived installation access token is minted and used in place of github_token. Use FLEET_GITOPS_GITHUB_APP_ID environment variable.",
+        },
+        "github_app_installation_id": {
+            "required": False,
+            "description": "GitHub App installation ID (numeric). Found at the URL of the App's installation on the org/repo. Use FLEET_GITOPS_GITHUB_APP_INSTALLATION_ID environment variable.",
+        },
+        "github_app_private_key_path": {
+            "required": False,
+            "description": "Filesystem path to the GitHub App's private key in PEM format (chmod 600). The key is never logged and is passed to openssl via -sign. Use FLEET_GITOPS_GITHUB_APP_PRIVATE_KEY_PATH environment variable.",
         },
         "s3_retention_versions": {
             "required": False,
@@ -929,7 +942,31 @@ class FleetImporter(Processor):
         gitops_software_dir = self.env.get("gitops_software_dir", "lib/macos/software")
         gitops_team_yaml_path = self.env.get("gitops_team_yaml_path")
         github_token = self.env.get("github_token")
+        github_app_id = self.env.get("github_app_id")
+        github_app_installation_id = self.env.get("github_app_installation_id")
+        github_app_private_key_path = self.env.get("github_app_private_key_path")
         s3_retention_versions = int(self.env.get("s3_retention_versions", 0))
+
+        have_app_creds = bool(
+            github_app_id and github_app_installation_id and github_app_private_key_path
+        )
+
+        # Warn if App config is partial — silent fallback to PAT is easy to miss.
+        _app_fields = (
+            ("github_app_id", github_app_id),
+            ("github_app_installation_id", github_app_installation_id),
+            ("github_app_private_key_path", github_app_private_key_path),
+        )
+        _set_app_fields = [n for n, v in _app_fields if v]
+        if 0 < len(_set_app_fields) < 3:
+            _missing_app_fields = [n for n, v in _app_fields if not v]
+            self.output(
+                "WARNING: Partial GitHub App configuration detected — "
+                f"set: {', '.join(_set_app_fields)}; "
+                f"missing: {', '.join(_missing_app_fields)}. "
+                "GitHub App auth will NOT be used; falling back to PAT. "
+                "Set all three github_app_* inputs (or none) to silence this warning."
+            )
 
         # Validate required GitOps parameters
         if not all(
@@ -938,12 +975,39 @@ class FleetImporter(Processor):
                 aws_cloudfront_domain,
                 gitops_repo_url,
                 gitops_team_yaml_path,
-                github_token,
             ]
-        ):
+        ) or not (have_app_creds or github_token):
             raise ProcessorError(
                 "GitOps mode requires: aws_s3_bucket, aws_cloudfront_domain, "
-                "gitops_repo_url, gitops_team_yaml_path, and github_token"
+                "gitops_repo_url, gitops_team_yaml_path, and EITHER "
+                "(github_app_id + github_app_installation_id + github_app_private_key_path) "
+                "OR github_token"
+            )
+
+        # Prefer GitHub App auth so PRs are authored by the App's bot identity
+        # rather than the human user behind the PAT. The minted installation
+        # token is itself a Bearer credential the rest of the workflow can use
+        # interchangeably with a PAT for both git HTTPS and the REST API.
+        using_github_app = False
+        if have_app_creds:
+            _, _, _, api_base = self._parse_github_repo_url(gitops_repo_url)
+            self.output("Minting GitHub App installation token...")
+            github_token = self._get_installation_token(
+                api_base,
+                github_app_id,
+                github_app_installation_id,
+                github_app_private_key_path,
+            )
+            using_github_app = True
+            self.output(
+                f"Using GitHub App authentication (App ID {github_app_id}, "
+                f"installation {github_app_installation_id}) — PRs and commits "
+                "will be authored by the App's bot identity."
+            )
+        else:
+            self.output(
+                "Using PAT authentication — PRs and commits will be authored "
+                "by the PAT owner."
             )
 
         # Fleet deployment options
@@ -1187,6 +1251,9 @@ class FleetImporter(Processor):
                 team_yaml_path,
                 icon_relative_path,
                 policy_yaml_path,
+                github_token=github_token,
+                using_github_app=using_github_app,
+                github_app_id=github_app_id,
             )
             self.env["git_branch"] = branch_name
 
@@ -2111,7 +2178,7 @@ class FleetImporter(Processor):
 
         Args:
             repo_url: Git repository URL
-            github_token: GitHub personal access token
+            github_token: GitHub PAT or App installation access token
 
         Returns:
             Path to temporary directory containing cloned repo
@@ -2120,27 +2187,8 @@ class FleetImporter(Processor):
             ProcessorError: If clone fails
         """
         temp_dir = tempfile.mkdtemp(prefix="fleetimporter-gitops-")
-        askpass_script = None
-
+        askpass_script, git_env = self._make_git_auth_env(github_token)
         try:
-            # Create a temporary GIT_ASKPASS script to provide credentials securely
-            # This avoids embedding tokens in URLs where they could be logged
-            askpass_fd, askpass_script = tempfile.mkstemp(
-                prefix="git-askpass-", suffix=".sh", text=True
-            )
-            os.write(askpass_fd, f'#!/bin/sh\necho "{github_token}"\n'.encode())
-            os.close(askpass_fd)
-            os.chmod(askpass_script, 0o700)
-
-            # Set up minimal environment for git clone
-            git_env = {
-                "GIT_ASKPASS": askpass_script,
-                "GIT_TERMINAL_PROMPT": "0",
-                "PATH": os.environ.get("PATH", ""),
-                "HOME": os.environ.get("HOME", ""),
-            }
-
-            # Clone repository using GIT_ASKPASS for authentication
             subprocess.run(
                 ["git", "clone", repo_url, temp_dir],
                 check=True,
@@ -2150,14 +2198,12 @@ class FleetImporter(Processor):
             )
             return temp_dir
         except subprocess.CalledProcessError as e:
-            # Clean up temp dir on failure
             if Path(temp_dir).exists():
                 shutil.rmtree(temp_dir, ignore_errors=True)
             raise ProcessorError(
                 f"Failed to clone GitOps repository: {e.stderr or e.stdout}"
             )
         finally:
-            # Clean up the askpass script
             if askpass_script and os.path.exists(askpass_script):
                 try:
                     os.unlink(askpass_script)
@@ -2360,6 +2406,9 @@ class FleetImporter(Processor):
         team_yaml_path: str,
         icon_path: str = None,
         policy_yaml_path: str = None,
+        github_token: str = None,
+        using_github_app: bool = False,
+        github_app_id: str = None,
     ):
         """Create Git branch, commit changes, and push to remote.
 
@@ -2372,18 +2421,27 @@ class FleetImporter(Processor):
             team_yaml_path: Relative path to team YAML file
             icon_path: Optional relative path to icon file (e.g., ../../icons/claude.png)
             policy_yaml_path: Optional relative path to policy YAML file (e.g., lib/policies/chrome.yml)
+            github_token: PAT or App installation access token used for the push.
+            using_github_app: When True, set commit author to the App bot so commits
+                aren't attributed to the host user.
+            github_app_id: App ID, used to construct the bot's noreply email when
+                using_github_app is True.
 
         Raises:
             ProcessorError: If Git operations fail
         """
+        askpass_script = None
         try:
-            # Use explicit allowlist of environment variables for Git operations
-            # Only pass what Git actually needs, avoiding leakage of secrets
-            git_env = {
-                "GIT_TERMINAL_PROMPT": "0",
-                "PATH": os.environ.get("PATH", ""),
-                "HOME": os.environ.get("HOME", ""),
-            }
+            if github_token:
+                askpass_script, git_env = self._make_git_auth_env(github_token)
+            else:
+                # Fallback for callers that previously relied on a credential
+                # helper having cached creds during clone.
+                git_env = {
+                    "GIT_TERMINAL_PROMPT": "0",
+                    "PATH": os.environ.get("PATH", ""),
+                    "HOME": os.environ.get("HOME", ""),
+                }
 
             # Create and checkout new branch
             subprocess.run(
@@ -2394,6 +2452,34 @@ class FleetImporter(Processor):
                 text=True,
                 env=git_env,
             )
+
+            # When the workflow authenticated as a GitHub App, attribute the
+            # commit to the App's bot account so `git log` doesn't show the
+            # host user. PR author is set independently by whoever calls the
+            # create-PR API, but commit author is what most reviewers look at.
+            if using_github_app:
+                bot_name = "autopkg[bot]"
+                bot_email = (
+                    f"{github_app_id}+autopkg[bot]@users.noreply.github.com"
+                    if github_app_id
+                    else "autopkg[bot]@users.noreply.github.com"
+                )
+                subprocess.run(
+                    ["git", "config", "user.name", bot_name],
+                    cwd=repo_dir,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=git_env,
+                )
+                subprocess.run(
+                    ["git", "config", "user.email", bot_email],
+                    cwd=repo_dir,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=git_env,
+                )
 
             # Stage YAML files and icon
             # Convert relative paths (with ../) to paths relative to repo root
@@ -2446,6 +2532,12 @@ class FleetImporter(Processor):
             )
         except subprocess.CalledProcessError as e:
             raise ProcessorError(f"Git operation failed: {e.stderr or e.stdout}")
+        finally:
+            if askpass_script and os.path.exists(askpass_script):
+                try:
+                    os.unlink(askpass_script)
+                except Exception:
+                    pass  # Best effort cleanup
 
     def _parse_github_repo_url(self, repo_url: str) -> tuple[str, str, str, str]:
         """Parse a GitHub repo URL into (host, owner, repo, api_base).
@@ -2473,6 +2565,144 @@ class FleetImporter(Processor):
             else f"https://{host}/api/v3"
         )
         return host, owner, repo, api_base
+
+    @staticmethod
+    def _b64url(data: bytes) -> str:
+        """Base64url-encode bytes without padding (JWT format)."""
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    def _sign_jwt_rs256(self, payload: dict, private_key_path: str) -> str:
+        """Build a JWT signed with RS256 using a private key on disk.
+
+        Shells out to openssl so we don't add a Python crypto dependency.
+        The key is passed via ``-sign <path>`` so it never appears in argv
+        or the environment.
+        """
+        if not os.path.isfile(private_key_path):
+            raise ProcessorError(
+                f"GitHub App private key not found at: {private_key_path}"
+            )
+        header_b64 = self._b64url(b'{"alg":"RS256","typ":"JWT"}')
+        payload_b64 = self._b64url(
+            json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        )
+        signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+        try:
+            result = subprocess.run(
+                ["openssl", "dgst", "-sha256", "-sign", private_key_path, "-binary"],
+                input=signing_input,
+                check=True,
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            raise ProcessorError(
+                "openssl binary not found; required to sign GitHub App JWTs."
+            )
+        except subprocess.CalledProcessError as e:
+            # Do not echo stderr verbatim — it can contain key-format hints.
+            raise ProcessorError(
+                "Failed to sign JWT with GitHub App private key "
+                f"(openssl exit {e.returncode})."
+            )
+        return f"{header_b64}.{payload_b64}.{self._b64url(result.stdout)}"
+
+    def _get_installation_token(
+        self,
+        api_base: str,
+        app_id: str,
+        installation_id: str,
+        private_key_path: str,
+    ) -> str:
+        """Mint a GitHub App installation access token.
+
+        Args:
+            api_base: GitHub REST API base, e.g. https://api.github.com or
+                https://github.example.com/api/v3.
+            app_id: Numeric GitHub App ID.
+            installation_id: Numeric installation ID.
+            private_key_path: Path to the App's PEM private key.
+
+        Returns:
+            Installation access token (valid ~1 hour).
+        """
+        try:
+            app_id_int = int(str(app_id).strip())
+        except ValueError:
+            raise ProcessorError(f"github_app_id must be numeric, got: {app_id!r}")
+        now = int(time.time())
+        # 60s clock-skew tolerance on iat; 9-minute lifetime (max is 10).
+        jwt = self._sign_jwt_rs256(
+            {"iat": now - 60, "exp": now + 540, "iss": app_id_int},
+            private_key_path,
+        )
+        url = f"{api_base}/app/installations/{installation_id}/access_tokens"
+        headers = {
+            "Authorization": f"Bearer {jwt}",
+            "Accept": "application/vnd.github+json",
+        }
+        try:
+            req = urllib.request.Request(url, method="POST", headers=headers)
+            with urllib.request.urlopen(
+                req, timeout=30, context=self._get_ssl_context()
+            ) as resp:
+                if resp.getcode() != 201:
+                    raise ProcessorError(
+                        "GitHub API returned unexpected status when minting "
+                        f"installation token: {resp.getcode()}"
+                    )
+                data = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode()
+            raise ProcessorError(
+                f"Failed to mint GitHub App installation token: {e.code} {error_body}"
+            )
+        except urllib.error.URLError as e:
+            raise ProcessorError(
+                f"Failed to connect to GitHub API for installation token: {e}"
+            )
+        token = data.get("token")
+        if not token:
+            raise ProcessorError(
+                "GitHub API response missing 'token' field for installation token."
+            )
+        return token
+
+    def _make_git_auth_env(self, github_token: str) -> tuple[str, dict]:
+        """Create a temporary GIT_ASKPASS script and the git env that uses it.
+
+        The token is supplied to git via the ``GIT_AUTH_TOKEN`` env var so it
+        never lands on disk or in process argv. The askpass script answers
+        both the Username and Password prompts, which lets the same auth path
+        work for personal access tokens AND GitHub App installation tokens
+        (the latter requires username ``x-access-token``).
+
+        Returns:
+            (askpass_path, git_env). Caller must ``os.unlink(askpass_path)``
+            once all git operations are finished.
+        """
+        askpass_fd, askpass_path = tempfile.mkstemp(
+            prefix="git-askpass-", suffix=".sh", text=True
+        )
+        os.write(
+            askpass_fd,
+            (
+                "#!/bin/sh\n"
+                'case "$1" in\n'
+                '  Username*) echo "x-access-token" ;;\n'
+                '  *)         echo "$GIT_AUTH_TOKEN" ;;\n'
+                "esac\n"
+            ).encode(),
+        )
+        os.close(askpass_fd)
+        os.chmod(askpass_path, 0o700)
+        git_env = {
+            "GIT_ASKPASS": askpass_path,
+            "GIT_AUTH_TOKEN": github_token,
+            "GIT_TERMINAL_PROMPT": "0",
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+        }
+        return askpass_path, git_env
 
     def _remote_branch_exists(self, repo_dir: str, branch_name: str) -> bool:
         """Return True if ``branch_name`` exists on the ``origin`` remote.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ FleetImporter recipes support the following variables. Configuration can be set 
 | `AWS_DEFAULT_REGION` | Not used | Required | `us-east-1` | AWS region for S3 operations |
 | **GitOps Repository** | | | | |
 | `FLEET_GITOPS_REPO_URL` | Not used | Required | - | Git repository URL for Fleet configuration |
-| `FLEET_GITOPS_GITHUB_TOKEN` | Not used | Required | - | GitHub token with permissions to push commits and open pull requests (see GitHub token permissions below) |
+| `FLEET_GITOPS_GITHUB_TOKEN` | Not used | Required *or* App auth | - | GitHub personal access token. Required unless the three `FLEET_GITOPS_GITHUB_APP_*` inputs below are set (see [GitHub authentication](#github-authentication)) |
+| `FLEET_GITOPS_GITHUB_APP_ID` | Not used | Required *or* PAT | - | GitHub App ID (numeric). When set alongside the installation ID and private key path, FleetImporter mints a short-lived installation token so PRs are authored by the App's bot identity instead of a human user |
+| `FLEET_GITOPS_GITHUB_APP_INSTALLATION_ID` | Not used | Required *or* PAT | - | GitHub App installation ID (numeric). Found at the URL of the App's installation on the org/repo |
+| `FLEET_GITOPS_GITHUB_APP_PRIVATE_KEY_PATH` | Not used | Required *or* PAT | - | Filesystem path to the GitHub App's private key in PEM format (chmod 600). Never logged; passed to `openssl` via `-sign` |
 | `FLEET_GITOPS_SOFTWARE_DIR` | Not used | Optional | `lib/macos/software` | Directory for software YAML files in GitOps repo |
 | `FLEET_GITOPS_TEAM_YAML_PATH` | Not used | Optional | `teams/workstations.yml` | Path to team YAML file in GitOps repo |
 | **Software Configuration** | | | | |
@@ -132,19 +135,49 @@ Upload packages to S3 and create GitOps pull requests for Fleet configuration ma
 
 ### Required configuration
 
-Set via AutoPkg preferences:
+Set via AutoPkg preferences. The S3/CloudFront/repo lines are always required; pick **one** of the two GitHub auth blocks below.
 
 ```bash
+# Always required
 defaults write com.github.autopkg AWS_S3_BUCKET "my-fleet-packages"
 defaults write com.github.autopkg AWS_CLOUDFRONT_DOMAIN "cdn.example.com"
 defaults write com.github.autopkg AWS_ACCESS_KEY_ID "your-access-key"
 defaults write com.github.autopkg AWS_SECRET_ACCESS_KEY "your-secret-key"
 defaults write com.github.autopkg AWS_DEFAULT_REGION "us-east-1"
 defaults write com.github.autopkg FLEET_GITOPS_REPO_URL "https://github.com/org/fleet-gitops.git"
+
+# Option A: GitHub App — PRs are authored by the App's bot
+defaults write com.github.autopkg FLEET_GITOPS_GITHUB_APP_ID "123456"
+defaults write com.github.autopkg FLEET_GITOPS_GITHUB_APP_INSTALLATION_ID "7890123"
+defaults write com.github.autopkg FLEET_GITOPS_GITHUB_APP_PRIVATE_KEY_PATH "/etc/autopkg/fleet-app.pem"
+
+# Option B: personal access token — PRs are authored by the PAT owner
 defaults write com.github.autopkg FLEET_GITOPS_GITHUB_TOKEN "your-github-token"
 ```
 
-### GitHub token permissions
+If both Option A and Option B are configured, **App auth wins**: FleetImporter mints an installation token and the PAT is ignored. On each run the processor logs which mode is active (`Using GitHub App authentication ...` or `Using PAT authentication ...`), and emits a `WARNING:` if only one or two of the three `FLEET_GITOPS_GITHUB_APP_*` inputs are set so the silent fallback to PAT is visible.
+
+### GitHub authentication
+
+FleetImporter supports two ways to authenticate against the GitOps repository for clone, push, and PR creation. **GitHub App auth is recommended** because PRs are authored by the App's bot identity (e.g., `autopkg[bot]`) rather than the human running AutoPkg.
+
+#### Option A: GitHub App
+
+1. **Create a GitHub App** on the GitHub instance hosting your GitOps repo (github.com or your GitHub Enterprise server). Permissions required:
+   - **Contents: Read and write**
+   - **Pull requests: Read and write**
+   - **Metadata: Read** (auto-included)
+2. **Install the App** on the org or specifically on your GitOps repository.
+3. **Generate a private key** (PEM format) from the App's settings page and place it on the AutoPkg runner with restrictive permissions:
+   ```bash
+   sudo install -m 600 -o root downloaded-key.pem /etc/autopkg/fleet-app.pem
+   ```
+4. **Record the App ID** (from the App's settings page) and the **Installation ID** (visible in the URL of the App's installation page, e.g., `.../installations/7890123`).
+5. **Configure AutoPkg** with the three values shown in Option A above.
+
+Requirements: `openssl` must be on `PATH` (default on macOS) — FleetImporter shells out to it to sign the JWT used to mint installation tokens.
+
+#### Option B: Personal access token
 
 `FLEET_GITOPS_GITHUB_TOKEN` must be able to create branches, push commits, and open pull requests in your GitOps repository.
 
@@ -156,6 +189,8 @@ defaults write com.github.autopkg FLEET_GITOPS_GITHUB_TOKEN "your-github-token"
 - **Classic personal access token:**
   - **`repo`** scope (for private repositories)
   - **`public_repo`** scope can be used if the GitOps repository is public
+
+PRs created via this path are authored by the user who owns the PAT.
 
 ### GitOps workflow
 
@@ -365,8 +400,11 @@ All bundle identifiers and versions are automatically escaped to prevent SQL inj
 **GitOps mode issues**
 - Verify AWS credentials are configured
 - Check S3 bucket permissions for upload/delete operations
-- Ensure GitHub token has the required permissions (`Contents: Read and write`, `Pull requests: Read and write` for fine-grained tokens)
+- Ensure your GitHub credential has the required permissions:
+  - **PAT:** `Contents: Read and write`, `Pull requests: Read and write` (fine-grained), or `repo` scope (classic)
+  - **GitHub App:** `Contents: Read and write`, `Pull requests: Read and write`, and the App must be installed on the GitOps repository
 - Verify GitOps repository URL and paths are correct
+- Look for the per-run auth-mode line in the output (`Using GitHub App authentication ...` or `Using PAT authentication ...`) to confirm which credential is being used. A `WARNING: Partial GitHub App configuration detected` line means one or two of the three `FLEET_GITOPS_GITHUB_APP_*` inputs are set but not all three — set all three (or none) to fix.
 
 **Package upload failures**
 - Check package file exists and is readable


### PR DESCRIPTION
## Summary
- Add optional `github_app_id`, `github_app_installation_id`, and `github_app_private_key_path` inputs. When all three are set, the processor mints a short-lived installation access token via the GitHub REST API and uses it for clone, push, and PR creation — so PRs are authored by the App's bot identity (e.g. `autopkg[bot]`) rather than the human user behind a PAT.
- `github_token` continues to work as a fallback so existing runners aren't broken by the change but if all keys are added they supersede the github token.
- JWT is signed by shelling out to `openssl` (no new Python deps); private key is passed via `-sign <path>` and never appears in argv or env.

## Implementation notes
- New helpers: `_b64url`, `_sign_jwt_rs256`, `_get_installation_token`, and a shared `_make_git_auth_env` for the temporary `GIT_ASKPASS` script.
- `_run_gitops_workflow` validation now accepts either the App trio or a PAT and resolves the credential at the top of the run.
- The askpass script answers both the `Username` prompt (`x-access-token`) and the `Password` prompt (token via `GIT_AUTH_TOKEN` env var). This is required when the credential is a GitHub App installation token.
- `_commit_and_push` now authenticates the push explicitly instead of relying on a credential helper having cached creds during clone — the old path was already fragile and breaks outright with short-lived installation tokens.
- When App auth is in use, commits are attributed to `autopkg[bot] <APP_ID+autopkg[bot]@users.noreply.github.com>` so `git log` doesn't surface the host user.
- GHE-compatible: `_parse_github_repo_url` already returns the right `api_base` for GHE environments, so the `/app/installations/.../access_tokens` endpoint resolves correctly.

## Setup required on the AutoPkg runner
1. Create a GitHub App with permissions: **Contents: read & write**, **Pull requests: read & write**, **Metadata: read**.
2. Install it on the GitOps repo (org-wide install is fine).
3. Generate a private key, place at e.g. `/etc/autopkg/fleet-app.pem`, `chmod 600`.
4. Configure: ``` defaults write com.github.autopkg FLEET_GITOPS_GITHUB_APP_ID '<app-id>' defaults write com.github.autopkg FLEET_GITOPS_GITHUB_APP_INSTALLATION_ID '<installation-id>' defaults write com.github.autopkg FLEET_GITOPS_GITHUB_APP_PRIVATE_KEY_PATH '/etc/autopkg/fleet-app.pem' ```
5. Optionally unset `FLEET_GITOPS_GITHUB_TOKEN` once App auth is verified.

PR assisted by Claude