### PR TITLE
Fix GitOps script delivery and migrate to Fleet's current repo layout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,8 +56,11 @@ Always reference these instructions first and fallback to search or bash command
   - `export AWS_CLOUDFRONT_DOMAIN="d1234567890abc.cloudfront.net"`
   - `export FLEET_GITOPS_REPO_URL="https://github.com/org/fleet-gitops.git"`
   - `export FLEET_GITOPS_GITHUB_TOKEN="your-github-token"`
-  - `export FLEET_GITOPS_SOFTWARE_DIR="lib/macos/software"`
-  - `export FLEET_GITOPS_TEAM_YAML_PATH="teams/workstations.yml"`
+  - `export FLEET_GITOPS_SOFTWARE_DIR="platforms/macos/software"`
+  - `export FLEET_GITOPS_SCRIPTS_DIR="platforms/macos/scripts"`
+  - `export FLEET_GITOPS_ICONS_DIR="platforms/all/icons"`
+  - `export FLEET_GITOPS_POLICIES_DIR="platforms/macos/policies"`
+  - `export FLEET_GITOPS_TEAM_YAML_PATH="fleets/workstations.yml"`
 - Set `GIT_TERMINAL_PROMPT=0` to prevent interactive Git authentication prompts
 
 ### Testing and Validation
@@ -203,7 +206,7 @@ The FleetImporter processor automatically extracts and uploads application icons
 - **Path**: Manual icon paths are relative to recipe file directory or absolute
 - **API**: Uses Fleet's `PUT /api/v1/fleet/software/titles/:id/icon` endpoint
 - **Timing**: Icon is uploaded immediately after package upload (both direct and GitOps modes)
-- **GitOps**: Icons are copied to `lib/icons/` directory in GitOps repository with relative path references
+- **GitOps**: Icons are copied to `platforms/all/icons/` directory in GitOps repository with relative path references
 
 **How automatic extraction works:**
 1. Expands the `.pkg` file using `pkgutil --expand`
@@ -261,7 +264,7 @@ Process:
   - Adjust other optional variables as needed
 - Set mode-specific defaults:
   - `GITOPS_MODE`: Set to `false` for direct mode by default
-  - `FLEET_GITOPS_SOFTWARE_DIR` and `FLEET_GITOPS_TEAM_YAML_PATH`: Keep defaults unless you have specific requirements
+  - `FLEET_GITOPS_SOFTWARE_DIR`, `FLEET_GITOPS_SCRIPTS_DIR`, `FLEET_GITOPS_ICONS_DIR`, `FLEET_GITOPS_POLICIES_DIR`, and `FLEET_GITOPS_TEAM_YAML_PATH`: Keep defaults unless you have specific requirements
 - **Update PARENT_RECIPE_DEPENDENCIES.md**: If the recipe uses a parent from a repository not already listed in PARENT_RECIPE_DEPENDENCIES.md, add it to the documentation
   - Check the parent recipe's repository using `autopkg info <parent-recipe-id>`
   - Trace the full dependency chain (pkg recipes often depend on download recipes from other repos)

--- a/AgileBits/1Password8.fleet.recipe.yaml
+++ b/AgileBits/1Password8.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Anthropic/Claude.fleet.recipe.yaml
+++ b/Anthropic/Claude.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/AutoPkg/AutoPkg.fleet.recipe.yaml
+++ b/AutoPkg/AutoPkg.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Barebones/BBEdit.fleet.recipe.yaml
+++ b/Barebones/BBEdit.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,12 @@ All recipes must include these arguments in the `Input` section:
 - `automatic_install` must be set to `false`
 - `categories`: At least one category (required when `self_service: true`)
 - `gitops_mode`: Set to `false` by default (users can override to enable GitOps)
-- GitOps-specific paths:
-  - `FLEET_GITOPS_SOFTWARE_DIR` must be set to `lib/macos/software`
-  - `FLEET_GITOPS_TEAM_YAML_PATH` must be set to `teams/workstations.yml`
+- GitOps-specific paths (Fleet's current repo layout):
+  - `FLEET_GITOPS_SOFTWARE_DIR` must be set to `platforms/macos/software`
+  - `FLEET_GITOPS_SCRIPTS_DIR` must be set to `platforms/macos/scripts`
+  - `FLEET_GITOPS_ICONS_DIR` must be set to `platforms/all/icons`
+  - `FLEET_GITOPS_POLICIES_DIR` must be set to `platforms/macos/policies`
+  - `FLEET_GITOPS_TEAM_YAML_PATH` must be set to `fleets/workstations.yml`
 - Auto-update policy automation (optional feature):
   - `AUTO_UPDATE_ENABLED`: Set to `false` by default (users can override to enable)
   - `AUTO_UPDATE_POLICY_NAME`: Set to `autopkg-auto-update-%NAME%` template
@@ -153,7 +156,7 @@ When `AUTO_UPDATE_ENABLED` is set to `true`:
 
 2. **Policy Creation**:
    - Direct mode: Uses Fleet API to create/update policy with automatic installation
-   - GitOps mode: Creates policy YAML file in `lib/policies/` directory
+   - GitOps mode: Creates policy YAML file in `platforms/macos/policies/` directory
 
 3. **Automatic Installation**: Policy failure triggers self-service installation of the latest version
 

--- a/Caffeine/Caffeine.fleet.recipe.yaml
+++ b/Caffeine/Caffeine.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Cyberduck/Cyberduck.fleet.recipe.yaml
+++ b/Cyberduck/Cyberduck.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Docker/DockerDesktop.fleet.recipe.yaml
+++ b/Docker/DockerDesktop.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Dockutil/dockutil.fleet.recipe.yaml
+++ b/Dockutil/dockutil.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Dropbox/Dropbox.fleet.recipe.yaml
+++ b/Dropbox/Dropbox.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Elgato/ElgatoStreamDeck.fleet.recipe.yaml
+++ b/Elgato/ElgatoStreamDeck.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/ElliotJordan/RecipeRobot.fleet.recipe.yaml
+++ b/ElliotJordan/RecipeRobot.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Evernote/Evernote.fleet.recipe.yaml
+++ b/Evernote/Evernote.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Fleet/fleetctl.fleet.recipe.yaml
+++ b/Fleet/fleetctl.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -114,12 +114,28 @@ class FleetImporter(Processor):
         },
         "gitops_software_dir": {
             "required": False,
-            "default": "lib/macos/software",
-            "description": "Directory for software package YAMLs within GitOps repo (default: lib/macos/software). Use FLEET_GITOPS_SOFTWARE_DIR environment variable.",
+            "default": "platforms/macos/software",
+            "description": "Directory for software package YAMLs within GitOps repo (default: platforms/macos/software). Use FLEET_GITOPS_SOFTWARE_DIR environment variable.",
+        },
+        "gitops_scripts_dir": {
+            "required": False,
+            "default": "platforms/macos/scripts",
+            "description": "Directory for install/uninstall/post-install scripts and pre-install queries within GitOps repo (default: platforms/macos/scripts). Use FLEET_GITOPS_SCRIPTS_DIR environment variable.",
+        },
+        "gitops_icons_dir": {
+            "required": False,
+            "default": "platforms/all/icons",
+            "description": "Directory for software icons within GitOps repo (default: platforms/all/icons). Use FLEET_GITOPS_ICONS_DIR environment variable.",
+        },
+        "gitops_policies_dir": {
+            "required": False,
+            "default": "platforms/macos/policies",
+            "description": "Directory for auto-update policy YAMLs within GitOps repo (default: platforms/macos/policies). Use FLEET_GITOPS_POLICIES_DIR environment variable.",
         },
         "gitops_team_yaml_path": {
             "required": False,
-            "description": "Path to team YAML file within GitOps repo (required for GitOps mode), e.g., teams/team-name.yml. Use FLEET_GITOPS_TEAM_YAML_PATH environment variable.",
+            "default": "fleets/workstations.yml",
+            "description": "Path to team YAML file within GitOps repo (default: fleets/workstations.yml), e.g., fleets/team-name.yml. Use FLEET_GITOPS_TEAM_YAML_PATH environment variable.",
         },
         "github_token": {
             "required": False,
@@ -487,6 +503,7 @@ class FleetImporter(Processor):
     def _create_or_update_policy_gitops(
         self,
         repo_dir: str,
+        policies_dir: str,
         software_title: str,
         version: str,
         pkg_path: str,
@@ -495,6 +512,8 @@ class FleetImporter(Processor):
 
         Args:
             repo_dir: Path to Git repository
+            policies_dir: Repo-relative directory for policy YAMLs
+                (e.g. platforms/macos/policies)
             software_title: Software title (used to reference the software package)
             version: Software version
             pkg_path: Path to package file for bundle ID extraction
@@ -545,20 +564,20 @@ class FleetImporter(Processor):
             },
         }
 
-        # Create lib/policies directory if it doesn't exist
-        policies_dir = Path(repo_dir) / "lib" / "policies"
-        policies_dir.mkdir(parents=True, exist_ok=True)
+        # Create the policies directory if it doesn't exist
+        policies_path = Path(repo_dir) / policies_dir
+        policies_path.mkdir(parents=True, exist_ok=True)
 
         # Write policy file
         slug = self._slugify(software_title)
         policy_filename = f"{slug}.yml"
-        policy_path = policies_dir / policy_filename
+        policy_path = policies_path / policy_filename
 
-        self.output(f"Writing auto-update policy to: lib/policies/{policy_filename}")
+        self.output(f"Writing auto-update policy to: {policies_dir}/{policy_filename}")
         self._write_yaml(policy_path, policy_yaml)
 
-        # Return relative path for Git operations
-        return f"lib/policies/{policy_filename}"
+        # Return repo-relative path for Git operations
+        return f"{policies_dir}/{policy_filename}"
 
     def main(self):
         # Check if GitOps mode is enabled
@@ -612,47 +631,20 @@ class FleetImporter(Processor):
         if not display_name:
             display_name = software_title
 
-        # Read script files if paths are provided, otherwise use inline content
-        install_script_input = self.env.get("install_script", "")
-        uninstall_script_input = self.env.get("uninstall_script", "")
-        pre_install_query = self.env.get("pre_install_query", "")
-        post_install_script_input = self.env.get("post_install_script", "")
-
-        # Check if inputs look like file paths (end with .sh or contain /) or inline scripts
-        # If they look like paths, read the file content
-        install_script = (
-            self._read_script_file(install_script_input)
-            if (
-                install_script_input
-                and (
-                    install_script_input.endswith(".sh") or "/" in install_script_input
-                )
-            )
-            else install_script_input
+        # Resolve each script/query input to its literal content. Inputs may be
+        # either an inline body or a path to a file containing one; see
+        # _resolve_script_content for how the two are distinguished.
+        install_script = self._resolve_script_content(
+            self.env.get("install_script", "")
         )
-
-        uninstall_script = (
-            self._read_script_file(uninstall_script_input)
-            if (
-                uninstall_script_input
-                and (
-                    uninstall_script_input.endswith(".sh")
-                    or "/" in uninstall_script_input
-                )
-            )
-            else uninstall_script_input
+        uninstall_script = self._resolve_script_content(
+            self.env.get("uninstall_script", "")
         )
-
-        post_install_script = (
-            self._read_script_file(post_install_script_input)
-            if (
-                post_install_script_input
-                and (
-                    post_install_script_input.endswith(".sh")
-                    or "/" in post_install_script_input
-                )
-            )
-            else post_install_script_input
+        pre_install_query = self._resolve_script_content(
+            self.env.get("pre_install_query", "")
+        )
+        post_install_script = self._resolve_script_content(
+            self.env.get("post_install_script", "")
         )
 
         # Validate label targeting - only one of include/exclude allowed
@@ -926,24 +918,36 @@ class FleetImporter(Processor):
         aws_s3_bucket = self.env.get("aws_s3_bucket")
         aws_cloudfront_domain = self.env.get("aws_cloudfront_domain")
         gitops_repo_url = self.env.get("gitops_repo_url")
-        gitops_software_dir = self.env.get("gitops_software_dir", "lib/macos/software")
-        gitops_team_yaml_path = self.env.get("gitops_team_yaml_path")
+        gitops_software_dir = self._gitops_path(
+            "gitops_software_dir", "platforms/macos/software"
+        )
+        gitops_scripts_dir = self._gitops_path(
+            "gitops_scripts_dir", "platforms/macos/scripts"
+        )
+        gitops_icons_dir = self._gitops_path("gitops_icons_dir", "platforms/all/icons")
+        gitops_policies_dir = self._gitops_path(
+            "gitops_policies_dir", "platforms/macos/policies"
+        )
+        gitops_team_yaml_path = self._gitops_path(
+            "gitops_team_yaml_path", "fleets/workstations.yml"
+        )
         github_token = self.env.get("github_token")
         s3_retention_versions = int(self.env.get("s3_retention_versions", 0))
 
-        # Validate required GitOps parameters
+        # Validate required GitOps parameters. gitops_team_yaml_path is omitted
+        # here because it always resolves to a value (recipe Input or the
+        # default applied by _gitops_path).
         if not all(
             [
                 aws_s3_bucket,
                 aws_cloudfront_domain,
                 gitops_repo_url,
-                gitops_team_yaml_path,
                 github_token,
             ]
         ):
             raise ProcessorError(
                 "GitOps mode requires: aws_s3_bucket, aws_cloudfront_domain, "
-                "gitops_repo_url, gitops_team_yaml_path, and github_token"
+                "gitops_repo_url, and github_token"
             )
 
         # Fleet deployment options
@@ -959,47 +963,20 @@ class FleetImporter(Processor):
         if not display_name:
             display_name = software_title
 
-        # Read script files if paths are provided, otherwise use inline content
-        install_script_input = self.env.get("install_script", "")
-        uninstall_script_input = self.env.get("uninstall_script", "")
-        pre_install_query = self.env.get("pre_install_query", "")
-        post_install_script_input = self.env.get("post_install_script", "")
-
-        # Check if inputs look like file paths (end with .sh or contain /) or inline scripts
-        # If they look like paths, read the file content
-        install_script = (
-            self._read_script_file(install_script_input)
-            if (
-                install_script_input
-                and (
-                    install_script_input.endswith(".sh") or "/" in install_script_input
-                )
-            )
-            else install_script_input
+        # Resolve each script/query input to its literal content. Inputs may be
+        # either an inline body or a path to a file containing one; see
+        # _resolve_script_content for how the two are distinguished.
+        install_script = self._resolve_script_content(
+            self.env.get("install_script", "")
         )
-
-        uninstall_script = (
-            self._read_script_file(uninstall_script_input)
-            if (
-                uninstall_script_input
-                and (
-                    uninstall_script_input.endswith(".sh")
-                    or "/" in uninstall_script_input
-                )
-            )
-            else uninstall_script_input
+        uninstall_script = self._resolve_script_content(
+            self.env.get("uninstall_script", "")
         )
-
-        post_install_script = (
-            self._read_script_file(post_install_script_input)
-            if (
-                post_install_script_input
-                and (
-                    post_install_script_input.endswith(".sh")
-                    or "/" in post_install_script_input
-                )
-            )
-            else post_install_script_input
+        pre_install_query = self._resolve_script_content(
+            self.env.get("pre_install_query", "")
+        )
+        post_install_script = self._resolve_script_content(
+            self.env.get("post_install_script", "")
         )
 
         icon_path_str = self.env.get("icon", "").strip()
@@ -1059,13 +1036,20 @@ class FleetImporter(Processor):
                 self.env["pull_request_url"] = existing_pr_url
                 return
 
-            # Handle icon - either from manual path or auto-extraction
-            icon_relative_path = None
+            # Handle icon - either from manual path or auto-extraction.
+            # icon_yaml_path is referenced from the package YAML (relative to
+            # it); icon_repo_path is repo-root-relative for git staging.
+            icon_yaml_path = None
+            icon_repo_path = None
 
             if icon_path_str:
                 # Manual icon path provided
-                icon_relative_path = self._copy_icon_to_gitops_repo(
-                    temp_dir, icon_path_str, software_title
+                icon_yaml_path, icon_repo_path = self._copy_icon_to_gitops_repo(
+                    temp_dir,
+                    icon_path_str,
+                    software_title,
+                    gitops_icons_dir,
+                    gitops_software_dir,
                 )
             else:
                 # Try to extract icon from package automatically
@@ -1077,8 +1061,12 @@ class FleetImporter(Processor):
                         f"Successfully extracted icon: {extracted_icon_path.name}"
                     )
                     # Copy extracted icon to GitOps repo
-                    icon_relative_path = self._copy_icon_to_gitops_repo(
-                        temp_dir, str(extracted_icon_path), software_title
+                    icon_yaml_path, icon_repo_path = self._copy_icon_to_gitops_repo(
+                        temp_dir,
+                        str(extracted_icon_path),
+                        software_title,
+                        gitops_icons_dir,
+                        gitops_software_dir,
                     )
                 else:
                     self.output(
@@ -1129,9 +1117,10 @@ class FleetImporter(Processor):
 
             # Create software package YAML file
             self.output(f"Creating software package YAML in {gitops_software_dir}")
-            package_yaml_path = self._create_software_package_yaml(
+            package_yaml_path, script_repo_paths = self._create_software_package_yaml(
                 temp_dir,
                 gitops_software_dir,
+                gitops_scripts_dir,
                 software_title,
                 cloudfront_url,
                 hash_sha256,
@@ -1139,7 +1128,7 @@ class FleetImporter(Processor):
                 uninstall_script,
                 pre_install_query,
                 post_install_script,
-                icon_relative_path,
+                icon_yaml_path,
                 display_name,
             )
 
@@ -1165,6 +1154,7 @@ class FleetImporter(Processor):
                 try:
                     policy_yaml_path = self._create_or_update_policy_gitops(
                         temp_dir,
+                        gitops_policies_dir,
                         software_title,
                         version,
                         pkg_path,
@@ -1185,8 +1175,9 @@ class FleetImporter(Processor):
                 version,
                 package_yaml_path,
                 team_yaml_path,
-                icon_relative_path,
+                icon_repo_path,
                 policy_yaml_path,
+                script_repo_paths,
             )
             self.env["git_branch"] = branch_name
 
@@ -1236,50 +1227,103 @@ class FleetImporter(Processor):
         # Remove leading/trailing hyphens
         return slug.strip("-")
 
-    def _read_script_file(self, script_path_str: str) -> str:
-        """Read script content from a file path.
+    # Extensions that mark a single-line input as *intended* to be a file path
+    # rather than a one-line inline script/query.
+    _SCRIPT_PATH_EXTENSIONS = (".sh", ".zsh", ".bash", ".ps1", ".sql")
+
+    def _resolve_script_content(self, value: str) -> str:
+        """Resolve a script/query input to its literal content.
+
+        The input may be either an inline script/query body or a path to a
+        file containing one. We must not treat the mere presence of a "/" as
+        proof of a path: real script bodies are full of slashes (e.g.
+        "/usr/sbin/chown", the "#!/bin/sh" shebang). Resolution rules:
+
+          - Empty -> empty.
+          - Contains a newline, or starts with "#!" (shebang) -> inline body.
+            Paths never contain newlines, and a shebang is unambiguous.
+          - Single line that resolves to an existing file -> file contents.
+          - Single line ending in a known script/query extension but with no
+            such file on disk -> warn and return empty (it was meant to be a
+            path that doesn't exist - matches the prior "file not found"
+            behavior rather than silently shipping a bogus path).
+          - Anything else -> treat as an inline one-liner.
 
         Args:
-            script_path_str: Path to script file (relative or absolute)
+            value: Raw input - an inline body or a path (relative or absolute).
 
         Returns:
-            Script content as string, or empty string if file not found
+            The resolved script/query content as a string ("" if unresolved).
 
         Notes:
-            - If path is relative, resolves relative to recipe directory
-            - Returns empty string if file doesn't exist (with warning)
+            - Relative paths resolve against RECIPE_DIR when available.
         """
-        if not script_path_str:
+        if not value:
             return ""
 
-        script_path = Path(script_path_str)
+        # A newline or shebang means this is a body, never a path.
+        if "\n" in value or value.lstrip().startswith("#!"):
+            return value
 
-        # Resolve relative paths relative to recipe directory
+        # Single-line input: it might be a path to a script/query file.
+        script_path = Path(value)
         if not script_path.is_absolute():
             recipe_dir = self.env.get("RECIPE_DIR")
             if recipe_dir:
-                script_path = (Path(recipe_dir) / script_path_str).resolve()
+                script_path = (Path(recipe_dir) / value).resolve()
             else:
                 script_path = script_path.expanduser().resolve()
         else:
             script_path = script_path.expanduser().resolve()
 
-        if script_path.exists():
+        if script_path.is_file():
             try:
-                with open(script_path, "r", encoding="utf-8") as f:
-                    content = f.read()
+                content = script_path.read_text(encoding="utf-8")
                 self.output(f"Read script file: {script_path}")
                 return content
             except Exception as e:
                 self.output(
-                    f"Warning: Could not read script file {script_path}: {e}. Using empty script."
+                    f"Warning: Could not read script file {script_path}: {e}. "
+                    "Using empty script."
                 )
                 return ""
-        else:
+
+        # Looks like it was meant to be a path (by extension) but no file exists.
+        if value.endswith(self._SCRIPT_PATH_EXTENSIONS):
             self.output(
                 f"Warning: Script file not found: {script_path}. Using empty script."
             )
             return ""
+
+        # Otherwise it's a short inline one-liner script/query.
+        return value
+
+    # Matches an AutoPkg "%VARIABLE%" reference left unsubstituted because the
+    # variable was undefined in the recipe/CLI/prefs/parent chain.
+    _UNSUBSTITUTED_VAR = re.compile(r"^%[a-zA-Z_][a-zA-Z0-9_]*%$")
+
+    def _gitops_path(self, key: str, default: str) -> str:
+        """Resolve a GitOps path/dir input, falling back to the default.
+
+        Returns the default when the value is unset/empty or when AutoPkg left a
+        "%PLACEHOLDER%" unsubstituted (which happens when the corresponding
+        recipe Input variable is undefined). Without this guard an undefined
+        variable would be used literally — e.g. creating a directory named
+        "%FLEET_GITOPS_SCRIPTS_DIR%" — because AutoPkg's own default only
+        applies when the processor argument is absent entirely, not when it is
+        present but references an undefined variable.
+
+        Args:
+            key: Processor env key (e.g. "gitops_scripts_dir").
+            default: Value to use when unset/empty/unsubstituted.
+
+        Returns:
+            The configured path, or the default.
+        """
+        value = (self.env.get(key) or "").strip()
+        if not value or self._UNSUBSTITUTED_VAR.match(value):
+            return default
+        return value
 
     def _extract_icon_from_pkg(self, pkg_path: Path) -> Path | None:
         """Extract and convert app icon from a package to PNG format.
@@ -2044,17 +2088,28 @@ class FleetImporter(Processor):
             self.output(f"Warning: S3 cleanup failed: {e}")
 
     def _copy_icon_to_gitops_repo(
-        self, repo_dir: str, icon_path_str: str, software_title: str
-    ) -> str:
-        """Copy icon file to GitOps repository under lib/icons.
+        self,
+        repo_dir: str,
+        icon_path_str: str,
+        software_title: str,
+        icons_dir: str,
+        software_dir: str,
+    ) -> tuple:
+        """Copy icon file into the GitOps repository's icons directory.
 
         Args:
             repo_dir: Path to Git repository
             icon_path_str: Path to icon file (relative to recipe or absolute)
             software_title: Software title for naming
+            icons_dir: Repo-relative directory for icons (e.g. platforms/all/icons)
+            software_dir: Repo-relative directory holding the package YAML, used
+                to compute the icon's path relative to that YAML
 
         Returns:
-            Relative path from software YAML to icon (e.g., ../icons/claude.png)
+            Tuple of (yaml_relative_path, repo_relative_path):
+              - yaml_relative_path references the icon from the package YAML
+                (e.g. ../../all/icons/claude.png).
+              - repo_relative_path is relative to the repo root, for `git add`.
 
         Raises:
             ProcessorError: If icon file not found or invalid
@@ -2090,21 +2145,25 @@ class FleetImporter(Processor):
             )
 
         # Create icons directory in GitOps repo
-        icons_dir = Path(repo_dir) / "lib" / "icons"
-        icons_dir.mkdir(parents=True, exist_ok=True)
+        icons_path = Path(repo_dir) / icons_dir
+        icons_path.mkdir(parents=True, exist_ok=True)
 
         # Use slugified software title for icon filename
         slug = self._slugify(software_title)
         icon_filename = f"{slug}.png"
-        dest_icon_path = icons_dir / icon_filename
+        dest_icon_path = icons_path / icon_filename
 
         # Copy icon to GitOps repo
-        self.output(f"Copying icon to GitOps repo: lib/icons/{icon_filename}")
+        self.output(f"Copying icon to GitOps repo: {icons_dir}/{icon_filename}")
         shutil.copy2(icon_path, dest_icon_path)
 
-        # Return relative path from lib/macos/software to lib/icons
-        # From lib/macos/software/package.yml to lib/icons/icon.png = ../../icons/icon.png
-        return f"../../icons/{icon_filename}"
+        # repo-relative path for git staging; yaml-relative path (relative to the
+        # package YAML's directory) for the `icon.path` reference.
+        repo_relative_path = dest_icon_path.relative_to(repo_dir).as_posix()
+        yaml_relative_path = Path(
+            os.path.relpath(dest_icon_path, Path(repo_dir) / software_dir)
+        ).as_posix()
+        return yaml_relative_path, repo_relative_path
 
     def _clone_gitops_repo(self, repo_url: str, github_token: str) -> str:
         """Clone GitOps repository to a temporary directory.
@@ -2211,6 +2270,7 @@ class FleetImporter(Processor):
         self,
         repo_dir: str,
         software_dir: str,
+        scripts_dir: str,
         software_title: str,
         cloudfront_url: str,
         hash_sha256: str,
@@ -2220,12 +2280,13 @@ class FleetImporter(Processor):
         post_install_script: str,
         icon_path: str = None,
         display_name: str = "",
-    ) -> str:
-        """Create software package YAML file in lib/ directory.
+    ) -> tuple:
+        """Create the software package YAML in the GitOps software directory.
 
         Args:
             repo_dir: Path to Git repository
-            software_dir: Directory for software YAMLs (e.g., lib/macos/software)
+            software_dir: Directory for software YAMLs (e.g. platforms/macos/software)
+            scripts_dir: Directory for script/query files (e.g. platforms/macos/scripts)
             software_title: Software title
             cloudfront_url: CloudFront URL for package
             hash_sha256: SHA-256 hash of package
@@ -2233,11 +2294,17 @@ class FleetImporter(Processor):
             uninstall_script: Custom uninstall script
             pre_install_query: Pre-install query
             post_install_script: Post-install script
-            icon_path: Relative path to icon file in GitOps repo (e.g., ../icons/claude.png)
+            icon_path: Path to icon file relative to the package YAML
+                (e.g. ../../all/icons/claude.png)
             display_name: Custom display name for the software in Fleet UI
 
         Returns:
-            Relative path to created package YAML file (for use in team YAML)
+            Tuple of (package_yaml_relative_path, script_repo_paths):
+              - package_yaml_relative_path is the path from the team YAML to the
+                created package YAML (e.g. ../platforms/macos/software/chrome.yml).
+              - script_repo_paths is a list of repo-root-relative paths for any
+                script/query files written alongside the package YAML, so the
+                caller can stage them for commit.
 
         Raises:
             ProcessorError: If YAML creation fails
@@ -2261,23 +2328,88 @@ class FleetImporter(Processor):
         if icon_path:
             package_entry["icon"] = {"path": icon_path}
 
-        # Add optional script paths if provided
-        if install_script:
-            package_entry["install_script"] = {"path": install_script}
-        if uninstall_script:
-            package_entry["uninstall_script"] = {"path": uninstall_script}
-        if pre_install_query:
-            package_entry["pre_install_query"] = {"path": pre_install_query}
-        if post_install_script:
-            package_entry["post_install_script"] = {"path": post_install_script}
+        # Scripts and the pre-install query must be referenced by a *path* to a
+        # file in the repo; Fleet reads each file's contents during the GitOps
+        # run (install_script.path, post_install_script.path, etc.). They cannot
+        # be embedded inline, so write each non-empty value to its own file in
+        # the scripts directory and reference it by a path relative to this
+        # package YAML. See https://fleetdm.com/docs/configuration/yaml-files.
+        script_repo_paths = []
+        for field, kind, content, extension in (
+            ("install_script", "install", install_script, ".sh"),
+            ("uninstall_script", "uninstall", uninstall_script, ".sh"),
+            ("post_install_script", "postinstall", post_install_script, ".sh"),
+            ("pre_install_query", "preinstall-query", pre_install_query, ".sql"),
+        ):
+            if not content:
+                continue
+            repo_rel_path, yaml_rel_path = self._write_gitops_script(
+                repo_dir, software_dir, scripts_dir, slug, kind, content, extension
+            )
+            package_entry[field] = {"path": yaml_rel_path}
+            script_repo_paths.append(repo_rel_path)
 
         # Package YAML is a list with single entry
         self._write_yaml(package_path, [package_entry])
 
-        # Return relative path from team YAML to package YAML
-        # E.g., if team YAML is teams/team-name.yml and package is lib/macos/software/chrome.yml
-        # then relative path is ../lib/macos/software/chrome.yml
-        return f"../{software_dir}/{package_filename}"
+        # Return relative path from team YAML to package YAML.
+        # E.g. if team YAML is fleets/team-name.yml and package is
+        # platforms/macos/software/chrome.yml, the relative path is
+        # ../platforms/macos/software/chrome.yml
+        return f"../{software_dir}/{package_filename}", script_repo_paths
+
+    def _write_gitops_script(
+        self,
+        repo_dir: str,
+        software_dir: str,
+        scripts_dir: str,
+        slug: str,
+        kind: str,
+        content: str,
+        extension: str,
+    ) -> tuple:
+        """Write a script/query body to a file in the GitOps repo.
+
+        Fleet's GitOps software spec references scripts and the pre-install
+        query by *path* (install_script.path, post_install_script.path, etc.),
+        not inline content. This writes the resolved body to a standalone file
+        in the scripts directory and returns the paths needed to (a) reference
+        it from the package YAML and (b) stage it for commit.
+
+        Args:
+            repo_dir: Path to the cloned GitOps repository.
+            software_dir: Directory holding the package YAML (e.g.
+                platforms/macos/software), used to compute the relative reference.
+            scripts_dir: Directory for the script file (e.g.
+                platforms/macos/scripts), relative to the repo root.
+            slug: Slugified software title, used in the filename.
+            kind: Short descriptor of the script role (e.g. "postinstall").
+            content: The script or query body to write.
+            extension: File extension, including the leading dot (e.g. ".sh").
+
+        Returns:
+            Tuple of (repo_relative_path, yaml_relative_path):
+              - repo_relative_path is relative to the repo root, for `git add`.
+              - yaml_relative_path is relative to the package YAML directory,
+                for the `path:` reference inside the package YAML.
+        """
+        scripts_path = Path(repo_dir) / scripts_dir
+        scripts_path.mkdir(parents=True, exist_ok=True)
+
+        filename = f"{slug}-{kind}{extension}"
+        script_path = scripts_path / filename
+
+        # Normalize to a single trailing newline so files are POSIX-clean.
+        self.output(f"Writing {kind} script to: {scripts_dir}/{filename}")
+        script_path.write_text(content.rstrip("\n") + "\n", encoding="utf-8")
+
+        repo_relative_path = script_path.relative_to(repo_dir).as_posix()
+        # Reference relative to the package YAML's directory; Fleet resolves
+        # package-level script paths against the package YAML's location.
+        yaml_relative_path = Path(
+            os.path.relpath(script_path, Path(repo_dir) / software_dir)
+        ).as_posix()
+        return repo_relative_path, yaml_relative_path
 
     def _update_team_yaml(
         self,
@@ -2360,6 +2492,7 @@ class FleetImporter(Processor):
         team_yaml_path: str,
         icon_path: str = None,
         policy_yaml_path: str = None,
+        script_paths: list = None,
     ):
         """Create Git branch, commit changes, and push to remote.
 
@@ -2370,8 +2503,13 @@ class FleetImporter(Processor):
             version: Software version for commit message
             package_yaml_path: Relative path to package YAML file
             team_yaml_path: Relative path to team YAML file
-            icon_path: Optional relative path to icon file (e.g., ../../icons/claude.png)
-            policy_yaml_path: Optional relative path to policy YAML file (e.g., lib/policies/chrome.yml)
+            icon_path: Optional repo-root-relative path to the icon file
+                (e.g., platforms/all/icons/chrome.png)
+            policy_yaml_path: Optional repo-root-relative path to the policy YAML
+                file (e.g., platforms/macos/policies/chrome.yml)
+            script_paths: Optional list of repo-root-relative paths to script/
+                query files referenced by the package YAML (e.g.,
+                platforms/macos/scripts/chrome-postinstall.sh)
 
         Raises:
             ProcessorError: If Git operations fail
@@ -2395,25 +2533,26 @@ class FleetImporter(Processor):
                 env=git_env,
             )
 
-            # Stage YAML files and icon
-            # Convert relative paths (with ../) to paths relative to repo root
-            # package_yaml_path is like ../lib/macos/software/chrome.yml
-            # team_yaml_path is like Path object to teams/team-name.yml
+            # Stage YAML files and icon (all paths relative to the repo root).
+            # package_yaml_path is like ../platforms/macos/software/chrome.yml
+            # (relative to the team YAML); strip the leading ../ to get a
+            # repo-root-relative path. team_yaml_path is an absolute Path.
             pkg_file = package_yaml_path.replace("../", "")
             team_file = str(team_yaml_path.relative_to(repo_dir))
 
             files_to_add = [pkg_file, team_file]
 
-            # Add icon file if provided
+            # Add icon file if provided (already repo-root-relative)
             if icon_path:
-                # icon_path is like ../../icons/claude.png, need to convert to lib/icons/claude.png
-                icon_file = icon_path.replace("../../", "lib/")
-                files_to_add.append(icon_file)
+                files_to_add.append(icon_path)
 
-            # Add policy file if provided
+            # Add policy file if provided (already repo-root-relative)
             if policy_yaml_path:
-                # policy_yaml_path is already relative to repo root (e.g., lib/policies/chrome.yml)
                 files_to_add.append(policy_yaml_path)
+
+            # Add script/query files if provided (already repo-root-relative)
+            if script_paths:
+                files_to_add.extend(script_paths)
 
             subprocess.run(
                 ["git", "add"] + files_to_add,

--- a/GPGSuite/GPGSuite.fleet.recipe.yaml
+++ b/GPGSuite/GPGSuite.fleet.recipe.yaml
@@ -31,8 +31,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -55,6 +58,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Ghostty/Ghostty.fleet.recipe.yaml
+++ b/Ghostty/Ghostty.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/GitHub/GitHubCLI.fleet.recipe.yaml
+++ b/GitHub/GitHubCLI.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/GitHub/GithubDesktop.fleet.recipe.yaml
+++ b/GitHub/GithubDesktop.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Glean/Glean.fleet.recipe.yaml
+++ b/Glean/Glean.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Google/GoogleChrome.fleet.recipe.yaml
+++ b/Google/GoogleChrome.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Handbrake/Handbrake.fleet.recipe.yaml
+++ b/Handbrake/Handbrake.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Kitzy/IconGrabber.fleet.recipe.yaml
+++ b/Kitzy/IconGrabber.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/MacPaw/TheUnarchiver.fleet.recipe.yaml
+++ b/MacPaw/TheUnarchiver.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/MeetingBar/MeetingBar.fleet.recipe.yaml
+++ b/MeetingBar/MeetingBar.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Microsoft/VisualStudioCode.fleet.recipe.yaml
+++ b/Microsoft/VisualStudioCode.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/MothersRuin/SuspiciousPackage.fleet.recipe.yaml
+++ b/MothersRuin/SuspiciousPackage.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Mozilla/Firefox.fleet.recipe.yaml
+++ b/Mozilla/Firefox.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Mozilla/Thunderbird.fleet.recipe.yaml
+++ b/Mozilla/Thunderbird.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Munki/MunkiTools.fleet.recipe.yaml
+++ b/Munki/MunkiTools.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -53,6 +56,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/NorthPoleSecurity/NorthPoleSecSanta.fleet.recipe.yaml
+++ b/NorthPoleSecurity/NorthPoleSecSanta.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Notion/Notion.fleet.recipe.yaml
+++ b/Notion/Notion.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/OmniGroup/OmniDiskSweeper.fleet.recipe.yaml
+++ b/OmniGroup/OmniDiskSweeper.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/OmniGroup/OmniFocus.fleet.recipe.yaml
+++ b/OmniGroup/OmniFocus.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/OmniGroup/OmniGraffle.fleet.recipe.yaml
+++ b/OmniGroup/OmniGraffle.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/OmniGroup/OmniOutliner.fleet.recipe.yaml
+++ b/OmniGroup/OmniOutliner.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/OmniGroup/OmniPlan.fleet.recipe.yaml
+++ b/OmniGroup/OmniPlan.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Panic/Transmit.fleet.recipe.yaml
+++ b/Panic/Transmit.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Postman/Postman.fleet.recipe.yaml
+++ b/Postman/Postman.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ FleetImporter recipes support the following variables. Configuration can be set 
 | **GitOps Repository** | | | | |
 | `FLEET_GITOPS_REPO_URL` | Not used | Required | - | Git repository URL for Fleet configuration |
 | `FLEET_GITOPS_GITHUB_TOKEN` | Not used | Required | - | GitHub token with permissions to push commits and open pull requests (see GitHub token permissions below) |
-| `FLEET_GITOPS_SOFTWARE_DIR` | Not used | Optional | `lib/macos/software` | Directory for software YAML files in GitOps repo |
-| `FLEET_GITOPS_TEAM_YAML_PATH` | Not used | Optional | `teams/workstations.yml` | Path to team YAML file in GitOps repo |
+| `FLEET_GITOPS_SOFTWARE_DIR` | Not used | Optional | `platforms/macos/software` | Directory for software YAML files in GitOps repo |
+| `FLEET_GITOPS_SCRIPTS_DIR` | Not used | Optional | `platforms/macos/scripts` | Directory for install/uninstall/post-install scripts and pre-install queries in GitOps repo |
+| `FLEET_GITOPS_ICONS_DIR` | Not used | Optional | `platforms/all/icons` | Directory for software icons in GitOps repo |
+| `FLEET_GITOPS_POLICIES_DIR` | Not used | Optional | `platforms/macos/policies` | Directory for auto-update policy YAML files in GitOps repo |
+| `FLEET_GITOPS_TEAM_YAML_PATH` | Not used | Optional | `fleets/workstations.yml` | Path to team YAML file in GitOps repo |
 | **Software Configuration** | | | | |
 | `self_service` | Optional | Optional | `true` | Show software in Fleet Desktop |
 | `automatic_install` | Optional | Optional | `false` | Auto-install on matching devices |
@@ -161,7 +164,7 @@ defaults write com.github.autopkg FLEET_GITOPS_GITHUB_TOKEN "your-github-token"
 
 1. Package is uploaded to S3
 2. CloudFront URL is generated
-3. Software YAML files are created in GitOps repo
+3. Software YAML is created in the GitOps repo, along with any companion files it references (scripts/queries in `FLEET_GITOPS_SCRIPTS_DIR`, icon in `FLEET_GITOPS_ICONS_DIR`, auto-update policy in `FLEET_GITOPS_POLICIES_DIR`)
 4. Pull request is opened for review
 
 ---
@@ -203,7 +206,7 @@ Input:
   UNINSTALL_SCRIPT: uninstall-myapp.sh
 ```
 
-FleetImporter automatically detects file paths (scripts ending in `.sh` or containing `/`) and reads the file content. Relative paths are resolved relative to the recipe directory.
+FleetImporter distinguishes a path from inline content automatically: a value containing a newline or starting with a `#!` shebang is treated as an inline script body, while a single-line value is treated as a path and its file is read (relative paths resolve against the recipe directory). A single-line value ending in `.sh`, `.ps1`, or `.sql` that doesn't exist on disk is reported as a missing file. This means inline scripts that contain slashes (e.g. `/usr/sbin/chown`) are no longer mistaken for paths.
 
 **Benefits of script files:**
 - Keeps recipes clean and readable
@@ -245,6 +248,15 @@ All three script parameters support both inline and file path modes:
 - `install_script`: Custom installation script
 - `uninstall_script`: Custom uninstall script
 - `post_install_script`: Script to run after installation
+
+The `pre_install_query` parameter (osquery condition) is resolved the same way — provide the query inline or as a path to a file.
+
+### How scripts are delivered
+
+Regardless of how you provide a script, FleetImporter always resolves it to its content first, then delivers it according to the mode:
+
+- **Direct mode**: the script content is uploaded inline to Fleet's API.
+- **GitOps mode**: the content is written to a file in `FLEET_GITOPS_SCRIPTS_DIR` (default `platforms/macos/scripts`, e.g. `myapp-postinstall.sh`) and the package YAML references it by relative path. Fleet's GitOps spec requires `install_script.path` / `post_install_script.path` / etc. to point to a file in the repo, so inline content is never embedded directly into the package YAML.
 
 ---
 
@@ -299,7 +311,7 @@ When `automatic_update` is set to `true`, FleetImporter:
    - Link to install package automatically on policy failure
    - Platform targeting (macOS only)
 
-3. **Creates policy YAML** (GitOps mode): Writes policy definition to `lib/policies/` 
+3. **Creates policy YAML** (GitOps mode): Writes policy definition to `platforms/macos/policies/` 
 
 ### Policy naming
 

--- a/RaycastTechnologies/Raycast.fleet.recipe.yaml
+++ b/RaycastTechnologies/Raycast.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Signal/Signal.fleet.recipe.yaml
+++ b/Signal/Signal.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Slack/Slack.fleet.recipe.yaml
+++ b/Slack/Slack.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Tailscale/Tailscale.fleet.recipe.yaml
+++ b/Tailscale/Tailscale.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/UTM/UTM.fleet.recipe.yaml
+++ b/UTM/UTM.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/Unblocked/Unblocked.fleet.recipe.yaml
+++ b/Unblocked/Unblocked.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/VLC/VLC.fleet.recipe.yaml
+++ b/VLC/VLC.fleet.recipe.yaml
@@ -22,8 +22,11 @@ Input:
   labels_exclude_any: []
   
   gitops_mode: false
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -39,6 +42,9 @@ Process:
     post_install_script: "%POST_INSTALL_SCRIPT%"
     auto_update_policy_query: "%AUTOMATIC_UPDATE_POLICY_QUERY%"
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
     fleet_api_base: "%FLEET_API_BASE%"
     fleet_api_token: "%FLEET_API_TOKEN%"

--- a/Zoom/Zoom.fleet.recipe.yaml
+++ b/Zoom/Zoom.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/_templates/Template.fleet.recipe.yaml
+++ b/_templates/Template.fleet.recipe.yaml
@@ -29,8 +29,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -53,6 +56,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/iTerm2/iTerm2.fleet.recipe.yaml
+++ b/iTerm2/iTerm2.fleet.recipe.yaml
@@ -30,8 +30,11 @@ Input:
   gitops_mode: false
 
   # GitOps-specific options
-  FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software
-  FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml
+  FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software
+  FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts
+  FLEET_GITOPS_ICONS_DIR: platforms/all/icons
+  FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies
+  FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml
   s3_retention_versions: 0
 
 Process:
@@ -54,6 +57,9 @@ Process:
 
     # GitOps-specific options
     gitops_software_dir: "%FLEET_GITOPS_SOFTWARE_DIR%"
+    gitops_scripts_dir: "%FLEET_GITOPS_SCRIPTS_DIR%"
+    gitops_icons_dir: "%FLEET_GITOPS_ICONS_DIR%"
+    gitops_policies_dir: "%FLEET_GITOPS_POLICIES_DIR%"
     gitops_team_yaml_path: "%FLEET_GITOPS_TEAM_YAML_PATH%"
 
     # Direct mode arguments (read from AutoPkg preferences/env vars)

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,8 +20,11 @@ Validates that all recipe files comply with the style guide requirements:
 - ✅ `GITOPS_MODE` variable exists and defaults to `false` in combined recipes
 - ✅ `CATEGORIES` required when `SELF_SERVICE` is `true`
 - ✅ Only one of `LABELS_INCLUDE_ANY` or `LABELS_EXCLUDE_ANY` can be set (mutually exclusive)
-- ✅ `FLEET_GITOPS_SOFTWARE_DIR` must be set to `lib/macos/software`
-- ✅ `FLEET_GITOPS_TEAM_YAML_PATH` must be set to `teams/workstations.yml`
+- ✅ `FLEET_GITOPS_SOFTWARE_DIR` must be set to `platforms/macos/software`
+- ✅ `FLEET_GITOPS_SCRIPTS_DIR` must be set to `platforms/macos/scripts`
+- ✅ `FLEET_GITOPS_ICONS_DIR` must be set to `platforms/all/icons`
+- ✅ `FLEET_GITOPS_POLICIES_DIR` must be set to `platforms/macos/policies`
+- ✅ `FLEET_GITOPS_TEAM_YAML_PATH` must be set to `fleets/workstations.yml`
 - ✅ Categories use only supported Fleet values: `Browsers`, `Communication`, `Developer tools`, `Productivity`
 - ✅ All Process arguments properly reference Input variables (`%VARIABLE%` format)
 
@@ -73,13 +76,19 @@ Found 20 recipe files to validate
    ✅ SELF_SERVICE: true
    ✅ AUTOMATIC_INSTALL: false
    ✅ GITOPS_MODE: false (default)
-   ✅ FLEET_GITOPS_SOFTWARE_DIR: 'lib/macos/software'
-   ✅ FLEET_GITOPS_TEAM_YAML_PATH: 'teams/workstations.yml'
+   ✅ FLEET_GITOPS_SOFTWARE_DIR: 'platforms/macos/software'
+   ✅ FLEET_GITOPS_SCRIPTS_DIR: 'platforms/macos/scripts'
+   ✅ FLEET_GITOPS_ICONS_DIR: 'platforms/all/icons'
+   ✅ FLEET_GITOPS_POLICIES_DIR: 'platforms/macos/policies'
+   ✅ FLEET_GITOPS_TEAM_YAML_PATH: 'fleets/workstations.yml'
    ✅ CATEGORIES: ['Developer tools'] (required with SELF_SERVICE)
    ✅ Label Targeting: None (valid)
    ✅ Process self_service: '%SELF_SERVICE%'
    ✅ Process automatic_install: '%AUTOMATIC_INSTALL%'
    ✅ Process gitops_software_dir: '%FLEET_GITOPS_SOFTWARE_DIR%'
+   ✅ Process gitops_scripts_dir: '%FLEET_GITOPS_SCRIPTS_DIR%'
+   ✅ Process gitops_icons_dir: '%FLEET_GITOPS_ICONS_DIR%'
+   ✅ Process gitops_policies_dir: '%FLEET_GITOPS_POLICIES_DIR%'
    ✅ Process gitops_team_yaml_path: '%FLEET_GITOPS_TEAM_YAML_PATH%'
    ✅ Validation complete
 
@@ -117,8 +126,8 @@ Validated requirements:
    ✅ GITOPS_MODE set to false in combined recipes
    ✅ CATEGORIES required when SELF_SERVICE is true
    ✅ Only one of LABELS_INCLUDE_ANY/LABELS_EXCLUDE_ANY (mutually exclusive)
-   ✅ FLEET_GITOPS_SOFTWARE_DIR set to 'lib/macos/software'
-   ✅ FLEET_GITOPS_TEAM_YAML_PATH set to 'teams/workstations.yml'
+   ✅ FLEET_GITOPS_* directories match Fleet's repo layout
+   ✅ FLEET_GITOPS_TEAM_YAML_PATH set to 'fleets/workstations.yml'
    ✅ Categories use only supported values (when specified)
    ✅ All Process arguments reference Input variables correctly
 ```
@@ -193,10 +202,14 @@ Input:
 
 ### Test Fails with GitOps Path Errors
 
-All recipes (both combined and legacy) must include GitOps configuration paths:
-- `FLEET_GITOPS_SOFTWARE_DIR: lib/macos/software` in Input section
-- `FLEET_GITOPS_TEAM_YAML_PATH: teams/workstations.yml` in Input section
-- Both values referenced in Process arguments (for combined recipes)
+All recipes (both combined and legacy) must include GitOps configuration paths
+(Fleet's current repo layout):
+- `FLEET_GITOPS_SOFTWARE_DIR: platforms/macos/software` in Input section
+- `FLEET_GITOPS_SCRIPTS_DIR: platforms/macos/scripts` in Input section
+- `FLEET_GITOPS_ICONS_DIR: platforms/all/icons` in Input section
+- `FLEET_GITOPS_POLICIES_DIR: platforms/macos/policies` in Input section
+- `FLEET_GITOPS_TEAM_YAML_PATH: fleets/workstations.yml` in Input section
+- All values referenced in Process arguments (for combined recipes)
 
 ### Test Fails with Invalid Categories
 

--- a/tests/test_script_resolution.py
+++ b/tests/test_script_resolution.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""
+Regression tests for script/query resolution in FleetImporter.
+
+These guard two related bugs that broke custom install/post-install/uninstall
+scripts (and pre-install queries) in GitOps mode:
+
+1. The path-vs-inline heuristic used to treat any input containing "/" as a
+   file path. Real shell scripts are full of slashes ("/usr/sbin/chown", the
+   "#!/bin/sh" shebang), so inline scripts were misread as paths, the "file"
+   wasn't found, and the script was silently dropped.
+
+2. GitOps mode wrote the resolved script *contents* into a YAML "path:" field.
+   Fleet's GitOps spec expects install_script.path / post_install_script.path /
+   etc. to point to a file in the repo whose contents it reads. Dumping the body
+   into "path:" made `fleetctl gitops` try to open the script body as a filename
+   (e.g. "platforms/macos/software/#!/bin/sh ... exit 0: no such file or directory").
+
+Unlike the other test modules, these import the real FleetImporter so the actual
+implementation is exercised; AutoPkg is stubbed so it can run without AutoPkg
+installed.
+"""
+
+import os
+import re
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+# PyYAML's libyaml C-extension currently segfaults on import under Python 3.14+
+# (see test_style_guide_compliance.py). FleetImporter imports yaml, so guard.
+if sys.version_info >= (3, 14):
+    sys.stderr.write(
+        "ERROR: Python {}.{} is not supported for this test suite. "
+        "Use Python 3.13 (see .python-version).\n".format(
+            sys.version_info.major, sys.version_info.minor
+        )
+    )
+    sys.exit(1)
+
+import yaml  # noqa: E402
+
+# Stub the autopkglib module so FleetImporter imports without AutoPkg installed.
+if "autopkglib" not in sys.modules:
+    _stub = types.ModuleType("autopkglib")
+
+    class _Processor:
+        def __init__(self):
+            self.env = {}
+
+        def output(self, msg):
+            pass
+
+    class _ProcessorError(Exception):
+        pass
+
+    _stub.Processor = _Processor
+    _stub.ProcessorError = _ProcessorError
+    sys.modules["autopkglib"] = _stub
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "FleetImporter"))
+
+import FleetImporter  # noqa: E402
+
+# The exact post-install script from the bug report: multi-line, full of slashes.
+ISLAND_POST_INSTALL = (
+    "#!/bin/sh\n\n"
+    '/usr/sbin/chown -R "$(stat -f%Su /dev/console)" "/Applications/Island.app"\n\n'
+    "exit 0\n"
+)
+
+
+class TestResolveScriptContent(unittest.TestCase):
+    """Tests for FleetImporter._resolve_script_content path-vs-inline logic."""
+
+    def setUp(self):
+        self.fi = FleetImporter.FleetImporter()
+        self.fi.env = {}
+
+    def test_multiline_script_with_slashes_is_inline(self):
+        # The original failing case must be treated as an inline body, verbatim.
+        self.assertEqual(
+            self.fi._resolve_script_content(ISLAND_POST_INSTALL),
+            ISLAND_POST_INSTALL,
+        )
+
+    def test_single_line_command_with_slashes_is_inline(self):
+        cmd = "installer -pkg /tmp/x.pkg -target /"
+        self.assertEqual(self.fi._resolve_script_content(cmd), cmd)
+
+    def test_single_line_sql_query_is_inline(self):
+        query = "SELECT 1 FROM apps WHERE bundle_identifier = 'com.example'"
+        self.assertEqual(self.fi._resolve_script_content(query), query)
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(self.fi._resolve_script_content(""), "")
+
+    def test_existing_file_path_is_read(self):
+        with tempfile.TemporaryDirectory() as d:
+            script = Path(d) / "postinstall.sh"
+            script.write_text("#!/bin/sh\necho hi\n")
+            self.assertEqual(
+                self.fi._resolve_script_content(str(script)),
+                "#!/bin/sh\necho hi\n",
+            )
+
+    def test_missing_script_path_returns_empty(self):
+        # Single-line, script-like extension, no such file -> empty (not the
+        # literal string), preserving the prior "file not found" behavior.
+        self.assertEqual(
+            self.fi._resolve_script_content("scripts/does-not-exist.sh"), ""
+        )
+
+
+class TestCreateSoftwarePackageYaml(unittest.TestCase):
+    """Tests that GitOps mode writes script files and references them by path."""
+
+    # Fleet's current repo layout (matches the processor defaults).
+    SOFTWARE_DIR = "platforms/macos/software"
+    SCRIPTS_DIR = "platforms/macos/scripts"
+
+    def setUp(self):
+        self.fi = FleetImporter.FleetImporter()
+        self.fi.env = {}
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _create(self, software_title, **scripts):
+        """Helper: invoke _create_software_package_yaml with sensible defaults."""
+        return self.fi._create_software_package_yaml(
+            str(self.repo),
+            scripts.get("software_dir", self.SOFTWARE_DIR),
+            scripts.get("scripts_dir", self.SCRIPTS_DIR),
+            software_title,
+            "https://cdn.example.com/pkg.pkg",
+            "a" * 64,
+            scripts.get("install_script", ""),
+            scripts.get("uninstall_script", ""),
+            scripts.get("pre_install_query", ""),
+            scripts.get("post_install_script", ""),
+            scripts.get("icon_path", None),
+            scripts.get("display_name", ""),
+        )
+
+    def _entry(self, software_dir, slug):
+        pkg_yaml = self.repo / software_dir / f"{slug}.yml"
+        return pkg_yaml, yaml.safe_load(pkg_yaml.read_text())[0]
+
+    def test_post_install_script_written_as_file_and_referenced_by_path(self):
+        _, script_paths = self._create(
+            "Island.app", post_install_script=ISLAND_POST_INSTALL
+        )
+
+        pkg_yaml, entry = self._entry(self.SOFTWARE_DIR, "island-app")
+
+        # The YAML must reference a *path*, and that path must not be the body.
+        self.assertIn("post_install_script", entry)
+        ref_path = entry["post_install_script"]["path"]
+        self.assertFalse(ref_path.startswith("#!"))
+        self.assertTrue(ref_path.endswith(".sh"))
+
+        # The path resolves (relative to the package YAML) to a real file whose
+        # contents are the script body.
+        resolved = (pkg_yaml.parent / ref_path).resolve()
+        self.assertTrue(resolved.is_file())
+        self.assertEqual(resolved.read_text(), ISLAND_POST_INSTALL)
+
+        # The returned repo-relative path is reported for git staging.
+        self.assertEqual(
+            script_paths, ["platforms/macos/scripts/island-app-postinstall.sh"]
+        )
+
+    def test_pre_install_query_written_as_file(self):
+        query = "SELECT 1 FROM apps WHERE bundle_identifier = 'com.example'"
+        _, script_paths = self._create("Example.app", pre_install_query=query)
+
+        pkg_yaml, entry = self._entry(self.SOFTWARE_DIR, "example-app")
+        ref_path = entry["pre_install_query"]["path"]
+        resolved = (pkg_yaml.parent / ref_path).resolve()
+        self.assertTrue(resolved.is_file())
+        self.assertEqual(resolved.read_text(), query + "\n")
+        self.assertEqual(
+            script_paths,
+            ["platforms/macos/scripts/example-app-preinstall-query.sql"],
+        )
+
+    def test_no_scripts_means_no_script_files(self):
+        _, script_paths = self._create("Bare.app")
+        self.assertEqual(script_paths, [])
+        _, entry = self._entry(self.SOFTWARE_DIR, "bare-app")
+        self.assertNotIn("post_install_script", entry)
+        self.assertNotIn("install_script", entry)
+
+    def test_custom_dirs_are_honored_with_correct_relative_path(self):
+        # Configurable dirs: the script lands in the custom scripts dir and the
+        # package YAML references it via a path relative to the package YAML.
+        _, script_paths = self._create(
+            "Island.app",
+            software_dir="custom/sw",
+            scripts_dir="custom/sh",
+            post_install_script=ISLAND_POST_INSTALL,
+        )
+        self.assertEqual(script_paths, ["custom/sh/island-app-postinstall.sh"])
+        pkg_yaml, entry = self._entry("custom/sw", "island-app")
+        # custom/sw -> custom/sh  ==  ../sh/island-app-postinstall.sh
+        self.assertEqual(
+            entry["post_install_script"]["path"],
+            "../sh/island-app-postinstall.sh",
+        )
+        self.assertTrue(
+            (pkg_yaml.parent / entry["post_install_script"]["path"]).is_file()
+        )
+
+
+class TestCopyIconToGitopsRepo(unittest.TestCase):
+    """Tests icon placement + relative referencing across configurable dirs."""
+
+    def setUp(self):
+        self.fi = FleetImporter.FleetImporter()
+        self.fi.env = {}
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_icon_repo_and_yaml_paths(self):
+        src = Path(self._tmp.name) / "src.png"
+        src.write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 32)  # tiny fake PNG
+        yaml_rel, repo_rel = self.fi._copy_icon_to_gitops_repo(
+            str(self.repo),
+            str(src),
+            "Island.app",
+            "platforms/all/icons",
+            "platforms/macos/software",
+        )
+        # repo-relative path for git staging
+        self.assertEqual(repo_rel, "platforms/all/icons/island-app.png")
+        self.assertTrue((self.repo / repo_rel).is_file())
+        # yaml-relative: platforms/macos/software -> platforms/all/icons
+        self.assertEqual(yaml_rel, "../../all/icons/island-app.png")
+
+
+class TestDirectUploadScriptDelivery(unittest.TestCase):
+    """Direct mode must send script *content* inline as multipart form fields.
+
+    This guards the other half of the delivery contract: GitOps writes files and
+    references them by path, while direct mode posts the resolved content inline
+    to POST /api/v1/fleet/software/package. It also catches positional-argument
+    mismatches between the call site and _fleet_upload_package's signature.
+    """
+
+    def setUp(self):
+        self.fi = FleetImporter.FleetImporter()
+        self.fi.env = {}
+        self._orig_urlopen = FleetImporter.urllib.request.urlopen
+
+    def tearDown(self):
+        FleetImporter.urllib.request.urlopen = self._orig_urlopen
+
+    @staticmethod
+    def _field(body, name):
+        match = re.search(r'name="%s"\r\n\r\n(.*?)\r\n--' % re.escape(name), body, re.S)
+        return match.group(1) if match else None
+
+    def _capture_upload_body(self, **kwargs):
+        captured = {}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return (
+                    b'{"software_package":{"title_id":1,'
+                    b'"installer_id":2,"hash_sha256":"x"}}'
+                )
+
+            def getcode(self):
+                return 200
+
+        def _fake_urlopen(req, timeout=None, context=None):
+            captured["body"] = req.data
+            return _FakeResp()
+
+        FleetImporter.urllib.request.urlopen = _fake_urlopen
+
+        with tempfile.TemporaryDirectory() as d:
+            pkg = Path(d) / "app.pkg"
+            pkg.write_bytes(b"PKGDATA")
+            self.fi._fleet_upload_package(
+                "https://fleet.example.com",
+                "tok",
+                pkg,
+                "Island.app",
+                "1.0",
+                2,
+                True,  # self_service
+                False,  # automatic_install
+                [],  # labels_include_any
+                [],  # labels_exclude_any
+                kwargs.get("install_script", ""),
+                kwargs.get("uninstall_script", ""),
+                kwargs.get("pre_install_query", ""),
+                kwargs.get("post_install_script", ""),
+                ["Browsers"],  # categories
+                "Island",  # display_name
+            )
+        return captured["body"].decode("utf-8", "replace")
+
+    def test_post_install_script_sent_inline(self):
+        # Resolve exactly as the direct workflow does, then upload.
+        resolved = self.fi._resolve_script_content(ISLAND_POST_INSTALL)
+        body = self._capture_upload_body(post_install_script=resolved)
+        # The full script body is present as a form field value...
+        self.assertEqual(self._field(body, "post_install_script"), ISLAND_POST_INSTALL)
+        # ...and it is NOT turned into a file path reference.
+        self.assertNotIn("platforms/macos/scripts", body)
+
+    def test_all_script_fields_sent_inline(self):
+        body = self._capture_upload_body(
+            install_script="echo install",
+            uninstall_script="echo uninstall",
+            pre_install_query="SELECT 1;",
+            post_install_script="echo post",
+        )
+        self.assertEqual(self._field(body, "install_script"), "echo install")
+        self.assertEqual(self._field(body, "uninstall_script"), "echo uninstall")
+        self.assertEqual(self._field(body, "pre_install_query"), "SELECT 1;")
+        self.assertEqual(self._field(body, "post_install_script"), "echo post")
+
+    def test_empty_scripts_omit_fields(self):
+        body = self._capture_upload_body()
+        self.assertIsNone(self._field(body, "install_script"))
+        self.assertIsNone(self._field(body, "post_install_script"))
+
+
+class TestGitopsPathFallback(unittest.TestCase):
+    """_gitops_path must fall back to the default for unset/empty values and
+    for AutoPkg %PLACEHOLDER% references that were left unsubstituted because
+    the recipe variable was undefined."""
+
+    # Mirrors the processor's GitOps path defaults.
+    DEFAULTS = {
+        "gitops_software_dir": "platforms/macos/software",
+        "gitops_scripts_dir": "platforms/macos/scripts",
+        "gitops_icons_dir": "platforms/all/icons",
+        "gitops_policies_dir": "platforms/macos/policies",
+        "gitops_team_yaml_path": "fleets/workstations.yml",
+    }
+
+    def setUp(self):
+        self.fi = FleetImporter.FleetImporter()
+        self.fi.env = {}
+
+    def test_uses_default_when_key_absent(self):
+        for key, default in self.DEFAULTS.items():
+            self.fi.env = {}
+            self.assertEqual(self.fi._gitops_path(key, default), default)
+
+    def test_uses_default_when_empty_or_whitespace(self):
+        for key, default in self.DEFAULTS.items():
+            for blank in ("", "   "):
+                self.fi.env = {key: blank}
+                self.assertEqual(self.fi._gitops_path(key, default), default)
+
+    def test_uses_default_when_placeholder_unsubstituted(self):
+        # AutoPkg leaves "%VAR%" intact when VAR is undefined; treat as unset.
+        placeholders = {
+            "gitops_software_dir": "%FLEET_GITOPS_SOFTWARE_DIR%",
+            "gitops_scripts_dir": "%FLEET_GITOPS_SCRIPTS_DIR%",
+            "gitops_icons_dir": "%FLEET_GITOPS_ICONS_DIR%",
+            "gitops_policies_dir": "%FLEET_GITOPS_POLICIES_DIR%",
+            "gitops_team_yaml_path": "%FLEET_GITOPS_TEAM_YAML_PATH%",
+        }
+        for key, placeholder in placeholders.items():
+            self.fi.env = {key: placeholder}
+            self.assertEqual(
+                self.fi._gitops_path(key, self.DEFAULTS[key]), self.DEFAULTS[key]
+            )
+
+    def test_honors_explicit_override(self):
+        self.fi.env = {"gitops_scripts_dir": "custom/scripts"}
+        self.assertEqual(
+            self.fi._gitops_path(
+                "gitops_scripts_dir", self.DEFAULTS["gitops_scripts_dir"]
+            ),
+            "custom/scripts",
+        )
+
+    def test_does_not_treat_real_path_with_percent_as_placeholder(self):
+        # A real value that merely contains '%' (not a full %VAR% token) is kept.
+        self.fi.env = {"gitops_scripts_dir": "platforms/macos/scripts%backup"}
+        self.assertEqual(
+            self.fi._gitops_path(
+                "gitops_scripts_dir", self.DEFAULTS["gitops_scripts_dir"]
+            ),
+            "platforms/macos/scripts%backup",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_style_guide_compliance.py
+++ b/tests/test_style_guide_compliance.py
@@ -12,8 +12,10 @@ This validates:
 6. automatic_install (or AUTOMATIC_INSTALL for legacy) must be set to false
 7. categories (or CATEGORIES for legacy) required when self_service is true
 8. gitops_mode (or GITOPS_MODE for legacy) variable exists in combined recipes (defaults to false)
-9. FLEET_GITOPS_SOFTWARE_DIR must be set to "lib/macos/software"
-10. FLEET_GITOPS_TEAM_YAML_PATH must be set to "teams/workstations.yml"
+9. FLEET_GITOPS_* directories must match Fleet's repo layout
+   (software: platforms/macos/software, scripts: platforms/macos/scripts,
+   icons: platforms/all/icons, policies: platforms/macos/policies)
+10. FLEET_GITOPS_TEAM_YAML_PATH must be set to "fleets/workstations.yml"
 11. Categories use only supported values
 12. Process arguments: lowercase Input variables auto-pass (preferred) or use %UPPERCASE% (legacy)
 13. Vendor folder structure
@@ -55,6 +57,24 @@ class StyleGuideValidator:
         "Communication",
         "Developer tools",
         "Productivity",
+    }
+
+    # GitOps Input path variables -> required value (Fleet's current repo layout).
+    GITOPS_INPUT_PATHS = {
+        "FLEET_GITOPS_SOFTWARE_DIR": "platforms/macos/software",
+        "FLEET_GITOPS_SCRIPTS_DIR": "platforms/macos/scripts",
+        "FLEET_GITOPS_ICONS_DIR": "platforms/all/icons",
+        "FLEET_GITOPS_POLICIES_DIR": "platforms/macos/policies",
+        "FLEET_GITOPS_TEAM_YAML_PATH": "fleets/workstations.yml",
+    }
+
+    # GitOps Process arguments -> the %MACRO% they must reference.
+    GITOPS_PROCESS_ARGS = {
+        "gitops_software_dir": "%FLEET_GITOPS_SOFTWARE_DIR%",
+        "gitops_scripts_dir": "%FLEET_GITOPS_SCRIPTS_DIR%",
+        "gitops_icons_dir": "%FLEET_GITOPS_ICONS_DIR%",
+        "gitops_policies_dir": "%FLEET_GITOPS_POLICIES_DIR%",
+        "gitops_team_yaml_path": "%FLEET_GITOPS_TEAM_YAML_PATH%",
     }
 
     def __init__(self):
@@ -156,8 +176,7 @@ class StyleGuideValidator:
 
         # Validate GitOps-specific paths (only for combined and legacy GitOps recipes)
         if is_combined or is_legacy_gitops:
-            self.validate_gitops_software_dir(recipe_path, input_section)
-            self.validate_gitops_team_yaml_path(recipe_path, input_section)
+            self.validate_gitops_paths(recipe_path, input_section)
 
         # Validate categories requirement (when self_service is true)
         self.validate_categories_requirement(recipe_path, input_section)
@@ -491,45 +510,22 @@ class StyleGuideValidator:
         else:
             print(f"   ✅ Label Targeting: None (valid)")
 
-    def validate_gitops_software_dir(self, recipe_path, input_section):
-        """Validate FLEET_GITOPS_SOFTWARE_DIR is set to 'lib/macos/software'."""
-        software_dir = input_section.get("FLEET_GITOPS_SOFTWARE_DIR")
-        expected = "lib/macos/software"
-
-        if software_dir is None:
-            self.errors.append(
-                f"{recipe_path}: Missing FLEET_GITOPS_SOFTWARE_DIR in Input section"
-            )
-            print(f"   ❌ FLEET_GITOPS_SOFTWARE_DIR: Missing (required for GitOps)")
-        elif software_dir != expected:
-            self.errors.append(
-                f"{recipe_path}: FLEET_GITOPS_SOFTWARE_DIR must be '{expected}', got '{software_dir}'"
-            )
-            print(
-                f"   ❌ FLEET_GITOPS_SOFTWARE_DIR: '{software_dir}' (must be '{expected}')"
-            )
-        else:
-            print(f"   ✅ FLEET_GITOPS_SOFTWARE_DIR: '{expected}'")
-
-    def validate_gitops_team_yaml_path(self, recipe_path, input_section):
-        """Validate FLEET_GITOPS_TEAM_YAML_PATH is set to 'teams/workstations.yml'."""
-        team_yaml_path = input_section.get("FLEET_GITOPS_TEAM_YAML_PATH")
-        expected = "teams/workstations.yml"
-
-        if team_yaml_path is None:
-            self.errors.append(
-                f"{recipe_path}: Missing FLEET_GITOPS_TEAM_YAML_PATH in Input section"
-            )
-            print(f"   ❌ FLEET_GITOPS_TEAM_YAML_PATH: Missing (required for GitOps)")
-        elif team_yaml_path != expected:
-            self.errors.append(
-                f"{recipe_path}: FLEET_GITOPS_TEAM_YAML_PATH must be '{expected}', got '{team_yaml_path}'"
-            )
-            print(
-                f"   ❌ FLEET_GITOPS_TEAM_YAML_PATH: '{team_yaml_path}' (must be '{expected}')"
-            )
-        else:
-            print(f"   ✅ FLEET_GITOPS_TEAM_YAML_PATH: '{expected}'")
+    def validate_gitops_paths(self, recipe_path, input_section):
+        """Validate the GitOps Input path variables match the expected layout."""
+        for var_name, expected in self.GITOPS_INPUT_PATHS.items():
+            value = input_section.get(var_name)
+            if value is None:
+                self.errors.append(
+                    f"{recipe_path}: Missing {var_name} in Input section"
+                )
+                print(f"   ❌ {var_name}: Missing (required for GitOps)")
+            elif value != expected:
+                self.errors.append(
+                    f"{recipe_path}: {var_name} must be '{expected}', got '{value}'"
+                )
+                print(f"   ❌ {var_name}: '{value}' (must be '{expected}')")
+            else:
+                print(f"   ✅ {var_name}: '{expected}'")
 
     def validate_process_arguments(self, recipe_path, args, is_combined):
         """Validate Process section arguments reference Input variables correctly.
@@ -578,31 +574,19 @@ class StyleGuideValidator:
 
         # Check combined recipe Process arguments (includes GitOps support)
         if is_combined:
-            software_dir_arg = args.get("gitops_software_dir")
-            if software_dir_arg != "%FLEET_GITOPS_SOFTWARE_DIR%":
-                self.errors.append(
-                    f"{recipe_path}: Process argument 'gitops_software_dir' must be '%FLEET_GITOPS_SOFTWARE_DIR%', got '{software_dir_arg}'"
-                )
-                print(
-                    f"   ❌ Process gitops_software_dir: '{software_dir_arg}' (must be '%FLEET_GITOPS_SOFTWARE_DIR%')"
-                )
-            else:
-                print(
-                    f"   ✅ Process gitops_software_dir: '%FLEET_GITOPS_SOFTWARE_DIR%'"
-                )
-
-            team_yaml_path_arg = args.get("gitops_team_yaml_path")
-            if team_yaml_path_arg != "%FLEET_GITOPS_TEAM_YAML_PATH%":
-                self.errors.append(
-                    f"{recipe_path}: Process argument 'gitops_team_yaml_path' must be '%FLEET_GITOPS_TEAM_YAML_PATH%', got '{team_yaml_path_arg}'"
-                )
-                print(
-                    f"   ❌ Process gitops_team_yaml_path: '{team_yaml_path_arg}' (must be '%FLEET_GITOPS_TEAM_YAML_PATH%')"
-                )
-            else:
-                print(
-                    f"   ✅ Process gitops_team_yaml_path: '%FLEET_GITOPS_TEAM_YAML_PATH%'"
-                )
+            for arg_name, expected_macro in self.GITOPS_PROCESS_ARGS.items():
+                arg_value = args.get(arg_name)
+                if arg_value != expected_macro:
+                    self.errors.append(
+                        f"{recipe_path}: Process argument '{arg_name}' must be "
+                        f"'{expected_macro}', got '{arg_value}'"
+                    )
+                    print(
+                        f"   ❌ Process {arg_name}: '{arg_value}' "
+                        f"(must be '{expected_macro}')"
+                    )
+                else:
+                    print(f"   ✅ Process {arg_name}: '{expected_macro}'")
 
     def report_results(self):
         """Print final validation report and return exit code."""
@@ -642,10 +626,10 @@ class StyleGuideValidator:
             print("   ✅ self_service set to true in all recipes")
             print("   ✅ automatic_install set to false in all recipes")
             print(
-                "   ✅ FLEET_GITOPS_SOFTWARE_DIR set to 'lib/macos/software' in GitOps recipes"
+                "   ✅ FLEET_GITOPS_* directories match Fleet's repo layout in GitOps recipes"
             )
             print(
-                "   ✅ FLEET_GITOPS_TEAM_YAML_PATH set to 'teams/workstations.yml' in GitOps recipes"
+                "   ✅ FLEET_GITOPS_TEAM_YAML_PATH set to 'fleets/workstations.yml' in GitOps recipes"
             )
             print("   ✅ Categories use only supported values (when specified)")
             print(


### PR DESCRIPTION
FleetImporter was writing custom script/query *contents* into a YAML `path:` field in GitOps mode, so `fleetctl gitops` tried to open the script body as a filename (e.g. "lib/macos/software/#!/bin/sh ...: no such file or directory"). The path-vs-inline heuristic also misread any input containing "/" as a file path, silently dropping inline scripts.

Changes:
- Replace the brittle ".sh or contains /" heuristic with _resolve_script_content: newline/shebang => inline body; single line that resolves to a file => file contents; single line with a script extension but no file => warn + empty; otherwise inline one-liner.
- GitOps mode now writes each script/query to a real file in the scripts dir and references it by a path relative to the package YAML, matching Fleet's spec (Fleet reads those files). Files are staged for commit.
- Direct mode unchanged in contract: resolved content is posted inline.

Migrate GitOps defaults to Fleet's current repo layout and make every asset directory configurable (like software already was):
- gitops_software_dir  -> platforms/macos/software
- gitops_scripts_dir   -> platforms/macos/scripts   (new)
- gitops_icons_dir      -> platforms/all/icons       (new)
- gitops_policies_dir  -> platforms/macos/policies   (new)
- gitops_team_yaml_path -> fleets/workstations.yml
All relative references computed with os.path.relpath; icon/policy/script
files staged via repo-root-relative paths. Updated the template, all 46
recipes, the style-guide test, README, CONTRIBUTING, tests/README, and
copilot-instructions.

Harden GitOps path resolution: _gitops_path falls back to the default when a value is unset/empty or an unsubstituted "%PLACEHOLDER%" (which AutoPkg leaves intact when the recipe variable is undefined). team YAML path gains a default and is dropped from the required-params check.

Add tests/test_script_resolution.py covering resolution, GitOps file emission + relative paths, direct-mode inline delivery, and the path fallback behavior.