### PR TITLE
fix: make GitOps auto-update policies valid and self-wiring

### DIFF
--- a/FleetImporter/FleetImporter.py
+++ b/FleetImporter/FleetImporter.py
@@ -507,6 +507,7 @@ class FleetImporter(Processor):
         software_title: str,
         version: str,
         pkg_path: str,
+        hash_sha256: str,
     ):
         """Create or update auto-update policy in GitOps repository.
 
@@ -517,11 +518,13 @@ class FleetImporter(Processor):
             software_title: Software title (used to reference the software package)
             version: Software version
             pkg_path: Path to package file for bundle ID extraction
+            hash_sha256: SHA-256 hash of the package (used to reference the
+                software package in install_software)
 
         Note:
-            In GitOps mode, the policy references software by name rather than ID.
-            Fleet will resolve the software_title to the appropriate software_title_id
-            when it processes the GitOps configuration.
+            In GitOps mode, the policy references the software package by its
+            SHA-256 hash. Fleet resolves the hash to the matching software
+            title when it processes the GitOps configuration.
         """
         # Build policy name
         policy_name = self._format_policy_name(software_title)
@@ -551,7 +554,9 @@ class FleetImporter(Processor):
         self.output(f"Auto-update policy query: {query}")
 
         # Create policy YAML structure
-        # In GitOps mode, reference software by name - Fleet will resolve to software_title_id
+        # In GitOps mode, reference the software package by its SHA-256 hash.
+        # Fleet's install_software requires one of package_path, app_store_id,
+        # hash_sha256, or fleet_maintained_app_slug (not a software title name).
         policy_yaml = {
             "name": policy_name,
             "query": query,
@@ -560,7 +565,7 @@ class FleetImporter(Processor):
             "platform": "darwin",
             "critical": False,
             "install_software": {
-                "name": software_title,
+                "hash_sha256": hash_sha256,
             },
         }
 
@@ -573,8 +578,11 @@ class FleetImporter(Processor):
         policy_filename = f"{slug}.yml"
         policy_path = policies_path / policy_filename
 
+        # Fleet expects a policy file referenced via `path:` to contain a list
+        # of policies ([]*spec.Policy), even when there's only one. Writing a
+        # bare object fails with: expected type []*spec.Policy but got object.
         self.output(f"Writing auto-update policy to: {policies_dir}/{policy_filename}")
-        self._write_yaml(policy_path, policy_yaml)
+        self._write_yaml(policy_path, [policy_yaml])
 
         # Return repo-relative path for Git operations
         return f"{policies_dir}/{policy_filename}"
@@ -1158,6 +1166,19 @@ class FleetImporter(Processor):
                         software_title,
                         version,
                         pkg_path,
+                        hash_sha256,
+                    )
+                    # Wire the policy into the same team YAML that references
+                    # the package. Fleet only honors the install_software
+                    # automation when the policy lives in the same team/fleet
+                    # that defines the software. policy_yaml_path is relative to
+                    # the repo root (e.g., platforms/macos/policies/chrome.yml);
+                    # the team YAML references it relative to itself (../...),
+                    # matching the convention used for package references.
+                    self._add_policy_to_team_yaml(
+                        team_yaml_path,
+                        f"../{policy_yaml_path}",
+                        software_title,
                     )
                 except Exception as e:
                     # Log warning but don't fail the entire workflow
@@ -2480,6 +2501,54 @@ class FleetImporter(Processor):
             packages_list.append(new_entry)
 
         data["software"]["packages"] = packages_list
+        self._write_yaml(team_yaml_path, data)
+
+    def _add_policy_to_team_yaml(
+        self,
+        team_yaml_path: Path,
+        policy_yaml_relative_path: str,
+        software_title: str,
+    ):
+        """Add an auto-update policy reference to the team/fleet YAML.
+
+        Fleet only honors the `install_software` policy automation when the
+        policy is defined in the same team/fleet that defines the software
+        package. This wires the generated policy file into the same team YAML
+        that references the package.
+
+        Args:
+            team_yaml_path: Path to team YAML file
+            policy_yaml_relative_path: Path to the policy YAML relative to the
+                team YAML (e.g., ../platforms/macos/policies/chrome.yml)
+            software_title: Software title (for logging)
+
+        Raises:
+            ProcessorError: If YAML update fails
+        """
+        data = self._read_yaml(team_yaml_path)
+
+        # Ensure policies section exists and is a list. Fleet parses a
+        # `path:`-referenced policies block as a list of references.
+        if not data.get("policies"):
+            data["policies"] = []
+
+        policies_list = data["policies"]
+
+        # Idempotent: skip if this policy file is already referenced, so
+        # per-version branch reruns don't create duplicate entries.
+        for entry in policies_list:
+            if (
+                isinstance(entry, dict)
+                and entry.get("path") == policy_yaml_relative_path
+            ):
+                self.output(
+                    f"Team YAML already references auto-update policy for {software_title}"
+                )
+                return
+
+        self.output(f"Adding auto-update policy reference for {software_title}")
+        policies_list.append({"path": policy_yaml_relative_path})
+        data["policies"] = policies_list
         self._write_yaml(team_yaml_path, data)
 
     def _commit_and_push(

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ When `automatic_update` is set to `true`, FleetImporter:
    - Link to install package automatically on policy failure
    - Platform targeting (macOS only)
 
-3. **Creates policy YAML** (GitOps mode): Writes policy definition to `platforms/macos/policies/` 
+3. **Creates policy YAML** (GitOps mode): Writes a policy definition to `platforms/macos/policies/` (as a list, per Fleet's GitOps schema), references the package by its `hash_sha256` in `install_software`, and wires a `path:` reference to the policy into the same team YAML that defines the package (required for Fleet to honor the `install_software` automation)
 
 ### Policy naming
 

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -229,6 +229,87 @@ class TestAutoUpdatePolicyPayload(unittest.TestCase):
         self.assertIn("3.3.12", payload["query"])
         self.assertIn("version_compare", payload["query"])
 
+    def test_gitops_install_software_uses_hash(self):
+        """GitOps policy install_software must reference the package by hash_sha256.
+
+        Fleet's install_software accepts only package_path, app_store_id,
+        hash_sha256, or fleet_maintained_app_slug -- not a software title name.
+        Mirrors the dict built in _create_or_update_policy_gitops.
+        """
+        hash_sha256 = "a" * 64
+        install_software = {
+            "hash_sha256": hash_sha256,
+        }
+
+        # The package must be referenced by hash, never by name.
+        self.assertIn("hash_sha256", install_software)
+        self.assertNotIn("name", install_software)
+        self.assertEqual(install_software["hash_sha256"], hash_sha256)
+
+    def test_gitops_policy_file_is_a_list(self):
+        """The policy file must contain a list of policies, not a bare object.
+
+        Fleet resolves a `path:`-referenced policy file as []*spec.Policy. A
+        single mapping fails with: expected type []*spec.Policy but got object.
+        Mirrors the value passed to _write_yaml in _create_or_update_policy_gitops.
+        """
+        policy_yaml = {
+            "name": "autopkg-auto-update-cisco-secure-client",
+            "query": "SELECT 1 ...",
+            "platform": "darwin",
+            "critical": False,
+            "install_software": {"hash_sha256": "a" * 64},
+        }
+        written = [policy_yaml]
+
+        self.assertIsInstance(written, list)
+        self.assertEqual(len(written), 1)
+        self.assertEqual(written[0]["name"], policy_yaml["name"])
+
+
+class TestAutoUpdateTeamPolicyWiring(unittest.TestCase):
+    """Test wiring the policy reference into the team/fleet YAML."""
+
+    @staticmethod
+    def add_policy_ref(data, policy_path):
+        """Replicate the core logic of _add_policy_to_team_yaml."""
+        if not data.get("policies"):
+            data["policies"] = []
+        for entry in data["policies"]:
+            if isinstance(entry, dict) and entry.get("path") == policy_path:
+                return data
+        data["policies"].append({"path": policy_path})
+        return data
+
+    def test_adds_policies_section_when_missing(self):
+        """A team YAML with no policies key gets one with the reference."""
+        data = {"software": {"packages": [{"path": "../lib/foo.yml"}]}}
+        result = self.add_policy_ref(data, "../platforms/macos/policies/foo.yml")
+
+        self.assertIn("policies", result)
+        self.assertEqual(
+            result["policies"], [{"path": "../platforms/macos/policies/foo.yml"}]
+        )
+        # Existing software section is preserved.
+        self.assertIn("software", result)
+
+    def test_appends_to_existing_policies(self):
+        """A new policy reference is appended alongside existing ones."""
+        data = {"policies": [{"path": "../platforms/macos/policies/bar.yml"}]}
+        result = self.add_policy_ref(data, "../platforms/macos/policies/foo.yml")
+
+        self.assertEqual(len(result["policies"]), 2)
+        self.assertIn(
+            {"path": "../platforms/macos/policies/foo.yml"}, result["policies"]
+        )
+
+    def test_is_idempotent(self):
+        """Re-adding the same policy path does not create a duplicate."""
+        data = {"policies": [{"path": "../platforms/macos/policies/foo.yml"}]}
+        result = self.add_policy_ref(data, "../platforms/macos/policies/foo.yml")
+
+        self.assertEqual(len(result["policies"]), 1)
+
 
 class TestAutoUpdateSQLInjectionPrevention(unittest.TestCase):
     """Test SQL injection prevention in query building."""


### PR DESCRIPTION
Setting up auto-update policies (`automatic_update: true`) for FleetImporter recipes in **GitOps mode** failed Fleet's dry run. This fixes three issues in the GitOps policy path, all surfaced by @mpanighetti while testing against Cisco Secure Client.

> Rebased onto current `main` so it includes the `platforms/macos/policies` layout from #75.

## 1. `install_software` referenced the package by name

The policy set `install_software: { name: <software title> }`. Fleet's `install_software` accepts only `package_path`, `app_store_id`, `hash_sha256`, or `fleet_maintained_app_slug` ([docs](https://fleetdm.com/docs/configuration/yaml-files#install-software)):

```
* unknown key "policies.[1].install_software.name"
* install_software must include either a package_path, an app_store_id, a hash_sha256 or a fleet_maintained_app_slug
```

Now references the package by its `hash_sha256` (already computed during the run), threaded into `_create_or_update_policy_gitops`.

## 2. Policy file was a bare object, not a list

A policy file referenced via `path:` is parsed as `[]*spec.Policy`, so a single mapping failed:

```
* Couldn't edit "...policies/cisco-secure-client.yml" at "policies", expected type []*spec.Policy but got object
```

Now written as a list, matching the existing software-package YAML.

## 3. Policy was never wired into the team/fleet YAML

The generated policy file was created but never referenced from the team YAML, so Fleet never applied the `install_software` automation (and users had to wire it by hand). Added `_add_policy_to_team_yaml`, which inserts a `path:` reference into the same team YAML that defines the package — required, since Fleet only honors the automation when the policy lives in the same team/fleet as the software. Idempotent, so per-version branch reruns don't duplicate entries.

The **direct-API** policy path is unaffected — it uses `software_title_id`, the correct field for that endpoint.

## Testing

- New regression tests: `install_software` uses hash (never `name`), policy file is a list, and team-wiring (adds section / appends / idempotent)
- All 38 unit tests pass; `py_compile` clean; black/isort/flake8 clean
- README's GitOps policy step updated

Note: unit tests replicate logic rather than importing the processor (no AutoPkg dependency), so a real `autopkg run` against Fleet is the final confirmation. cc @mpanighetti for a dry-run check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)